### PR TITLE
Decoder v2: improving and fixing tests and models

### DIFF
--- a/model/modeldecoder/modeldecodertest/stream_decoder.go
+++ b/model/modeldecoder/modeldecodertest/stream_decoder.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modeldecodertest
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/elastic/apm-server/decoder"
+)
+
+var json = jsoniter.ConfigFastest
+
+// TODO(simitt):
+// copied decoder from decoder package
+// remove this file again when the ReadAhaed functionality is introduced to
+// the decoder.StreamDecoder
+
+func newNDJSONStreamDecoder(r io.Reader, maxLineLength int) *ndjsonStreamDecoder {
+	var dec ndjsonStreamDecoder
+	dec.bufioReader = bufio.NewReaderSize(r, maxLineLength)
+	dec.lineReader = decoder.NewLineReader(dec.bufioReader, maxLineLength)
+	dec.resetDecoder()
+	return &dec
+}
+
+type ndjsonStreamDecoder struct {
+	bufioReader *bufio.Reader
+	lineReader  *decoder.LineReader
+
+	isEOF            bool
+	latestError      error
+	latestLine       []byte
+	latestLineReader bytes.Reader
+	decoder          *jsoniter.Decoder
+}
+
+func (dec *ndjsonStreamDecoder) resetDecoder() {
+	dec.decoder = json.NewDecoder(&dec.latestLineReader)
+	dec.decoder.UseNumber()
+}
+
+// Decode decodes the next line into v.
+func (dec *ndjsonStreamDecoder) decode(v interface{}) error {
+	defer dec.resetLatestLineReader()
+	if dec.latestLineReader.Size() == 0 {
+		dec.readAhead()
+	}
+	if len(dec.latestLine) == 0 || (dec.latestError != nil && !dec.isEOF) {
+		return dec.latestError
+	}
+	if err := dec.decoder.Decode(v); err != nil {
+		dec.resetDecoder() // clear out decoding state
+		return jsonDecodeError("data read error: " + err.Error())
+	}
+	return dec.latestError // this might be io.EOF
+}
+
+func (dec *ndjsonStreamDecoder) readAhead() ([]byte, error) {
+	// readLine can return valid data in `buf` _and_ also an io.EOF
+	line, readErr := dec.lineReader.ReadLine()
+	dec.latestLine = line
+	dec.latestLineReader.Reset(dec.latestLine)
+	dec.latestError = readErr
+	dec.isEOF = readErr == io.EOF
+	return line, readErr
+}
+
+func (dec *ndjsonStreamDecoder) resetLatestLineReader() {
+	dec.latestLineReader.Reset(nil)
+	dec.latestError = nil
+}
+
+type jsonDecodeError string
+
+func (s jsonDecodeError) Error() string { return string(s) }

--- a/model/modeldecoder/modeldecodertest/testdata.go
+++ b/model/modeldecoder/modeldecodertest/testdata.go
@@ -19,7 +19,7 @@ package modeldecodertest
 
 import (
 	"bytes"
-	"encoding/json"
+	"errors"
 	"io"
 	"testing"
 
@@ -31,29 +31,50 @@ import (
 // DecodeData decodes input from the io.Reader into the given output
 // it skips the metadata line if eventType is not set to metadata
 func DecodeData(t *testing.T, r io.Reader, eventType string, out interface{}) {
-	dec := decoder.NewJSONIteratorDecoder(r)
-	// skip first line (metadata) for all events but metadata
-	if eventType != "metadata" && eventType != "m" {
-		var data interface{}
-		require.NoError(t, dec.Decode(&data))
+	dec := newNDJSONStreamDecoder(r, 300*1024)
+	var et string
+	var err error
+	for et != eventType {
+		et, err = readEventType(dec)
+		require.NoError(t, err)
 	}
 	// decode data
-	require.NoError(t, dec.Decode(&out))
+	require.NoError(t, dec.decode(&out))
 }
 
 // DecodeDataWithReplacement decodes input from the io.Reader and replaces data for the
 // given key with the provided newData before decoding into the output
-func DecodeDataWithReplacement(t *testing.T, r io.Reader, eventType string, key string, newData string, out interface{}) {
+func DecodeDataWithReplacement(t *testing.T, r io.Reader, eventType string, newData string, out interface{}, keys ...string) {
 	var data map[string]interface{}
 	DecodeData(t, r, eventType, &data)
 	// replace data for given key with newData
-	eventData := data[eventType].(map[string]interface{})
+	d := data[eventType].(map[string]interface{})
+	for i := 0; i < len(keys)-1; i++ {
+		key := keys[i]
+		if _, ok := d[key]; !ok {
+			d[key] = map[string]interface{}{}
+		}
+		d = d[key].(map[string]interface{})
+	}
 	var keyData interface{}
 	require.NoError(t, json.Unmarshal([]byte(newData), &keyData))
-	eventData[key] = keyData
+	d[keys[len(keys)-1]] = keyData
 
 	// unmarshal data into  struct
-	b, err := json.Marshal(eventData)
+	b, err := json.Marshal(data[eventType])
 	require.NoError(t, err)
 	require.NoError(t, decoder.NewJSONIteratorDecoder(bytes.NewReader(b)).Decode(out))
+}
+
+func readEventType(d *ndjsonStreamDecoder) (string, error) {
+	body, err := d.readAhead()
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	body = bytes.TrimLeft(body, `{ "`)
+	end := bytes.Index(body, []byte(`"`))
+	if end == -1 {
+		return "", errors.New("invalid input: " + string(body))
+	}
+	return string(body[0:end]), nil
 }

--- a/model/modeldecoder/rumv3/metadata_test.go
+++ b/model/modeldecoder/rumv3/metadata_test.go
@@ -18,10 +18,6 @@
 package rumv3
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,34 +30,6 @@ import (
 	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
-
-type testcase struct {
-	name     string
-	errorKey string
-	data     string
-}
-
-func testdataReader(t *testing.T, typ string) io.Reader {
-	p := filepath.Join("..", "..", "..", "testdata", "intake-v3", fmt.Sprintf("%s.ndjson", typ))
-	r, err := os.Open(p)
-	require.NoError(t, err)
-	return r
-}
-
-func TestSetResetIsSet(t *testing.T) {
-	var m metadataRoot
-	require.NoError(t, decoder.NewJSONIteratorDecoder(testdataReader(t, "metadata")).Decode(&m))
-	require.True(t, m.IsSet())
-	require.NotEmpty(t, m.Metadata.Labels)
-	require.True(t, m.Metadata.Service.IsSet())
-	require.True(t, m.Metadata.User.IsSet())
-	// call Reset and ensure initial state, except for array capacity
-	m.Reset()
-	assert.False(t, m.IsSet())
-	assert.Equal(t, metadataService{}, m.Metadata.Service)
-	assert.Equal(t, user{}, m.Metadata.User)
-	assert.Empty(t, m.Metadata.Labels)
-}
 
 func TestMetadataResetModelOnRelease(t *testing.T) {
 	inp := `{"m":{"se":{"n":"service-a"}}}`
@@ -133,113 +101,4 @@ func TestDecodeMetadataMappingToModel(t *testing.T) {
 	mapToMetadataModel(&m, &modelM)
 	assert.Equal(t, expected("overwritten"), modelM)
 
-}
-
-func TestValidationRules(t *testing.T) {
-	testMetadata := func(t *testing.T, key string, tc testcase) {
-		var m metadata
-		r := testdataReader(t, "metadata")
-		modeldecodertest.DecodeDataWithReplacement(t, r, "m", key, tc.data, &m)
-
-		// run validation and checks
-		err := m.validate()
-		if tc.errorKey == "" {
-			assert.NoError(t, err)
-		} else {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.errorKey)
-		}
-	}
-
-	t.Run("user", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "id-string", data: `{"id":"user123"}`},
-			{name: "id-int", data: `{"id":44}`},
-			{name: "id-float", errorKey: "types", data: `{"id":45.6}`},
-			{name: "id-bool", errorKey: "types", data: `{"id":true}`},
-			{name: "id-string-max-len", data: `{"id":"` + modeldecodertest.BuildString(1024) + `"}`},
-			{name: "id-string-max-len", errorKey: "max", data: `{"id":"` + modeldecodertest.BuildString(1025) + `"}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testMetadata(t, "u", tc)
-			})
-		}
-	})
-
-	t.Run("service", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "name-valid-lower", data: `"n":"abcdefghijklmnopqrstuvwxyz"`},
-			{name: "name-valid-upper", data: `"n":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"`},
-			{name: "name-valid-digits", data: `"n":"0123456789"`},
-			{name: "name-valid-special", data: `"n":"_ -"`},
-			{name: "name-asterisk", errorKey: "'pattern(regexpAlphaNumericExt)", data: `"n":"abc*"`},
-			{name: "name-dot", errorKey: "'pattern(regexpAlphaNumericExt)", data: `"n":"abc."`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				tc.data = `{"a":{"n":"go","ve":"1.0"},` + tc.data + `}`
-				testMetadata(t, "se", tc)
-			})
-		}
-	})
-
-	t.Run("max-len", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "service-environment-max-len", data: `"en":"` + modeldecodertest.BuildString(1024) + `"`},
-			{name: "service-environment-max-len", errorKey: "max", data: `"en":"` + modeldecodertest.BuildString(1025) + `"`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				tc.data = `{"a":{"n":"go","ve":"1.0"},"n":"my-service",` + tc.data + `}`
-				testMetadata(t, "se", tc)
-			})
-		}
-	})
-
-	t.Run("labels", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "valid", data: `{"k1":"v1","k2":2.3,"k3":3,"k4":true,"k5":null}`},
-			{name: "restricted-type", errorKey: "typesVals", data: `{"k1":{"k2":"v1"}}`},
-			{name: "key-dot", errorKey: "patternKeys", data: `{"k.1":"v1"}`},
-			{name: "key-asterisk", errorKey: "patternKeys", data: `{"k*1":"v1"}`},
-			{name: "key-quotemark", errorKey: "patternKeys", data: `{"k\"1":"v1"}`},
-			{name: "max-len", data: `{"k1":"` + modeldecodertest.BuildString(1024) + `"}`},
-			{name: "max-len-exceeded", errorKey: "maxVals", data: `{"k1":"` + modeldecodertest.BuildString(1025) + `"}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testMetadata(t, "l", tc)
-			})
-		}
-	})
-
-	t.Run("required", func(t *testing.T) {
-		// setup: create full metadata struct with arbitrary values set
-		var metadata metadata
-		modeldecodertest.InitStructValues(&metadata)
-
-		// test vanilla struct is valid
-		require.NoError(t, metadata.validate())
-
-		// iterate through struct, remove every key one by one
-		// and test that validation behaves as expected
-		requiredKeys := map[string]interface{}{
-			"se":       nil, //service
-			"se.a":     nil, //service.agent
-			"se.a.n":   nil, //service.agent.name
-			"se.a.ve":  nil, //service.agent.version
-			"se.la.n":  nil, //service.language.name
-			"se.ru.n":  nil, //service.runtime.name
-			"se.ru.ve": nil, //service.runtime.version
-			"se.n":     nil, //service.name
-		}
-		modeldecodertest.SetZeroStructValue(&metadata, func(key string) {
-			err := metadata.validate()
-			if _, ok := requiredKeys[key]; ok {
-				require.Error(t, err, key)
-				for _, part := range strings.Split(key, ".") {
-					assert.Contains(t, err.Error(), part)
-				}
-			} else {
-				assert.NoError(t, err, key)
-			}
-		})
-	})
 }

--- a/model/modeldecoder/rumv3/model_test.go
+++ b/model/modeldecoder/rumv3/model_test.go
@@ -1,0 +1,279 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rumv3
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
+)
+
+func TestUserValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "id-string", data: `{"id":"user123"}`},
+		{name: "id-int", data: `{"id":44}`},
+		{name: "id-float", errorKey: "types", data: `{"id":45.6}`},
+		{name: "id-bool", errorKey: "types", data: `{"id":true}`},
+		{name: "id-string-max-len", data: `{"id":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "id-string-max-len", errorKey: "max", data: `{"id":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "m", testcases, "u")
+	testValidation(t, "x", testcases, "c", "u")
+}
+
+func TestServiceValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "name-valid-lower", data: `{"a":{"n":"go","ve":"1.0"},"n":"abcdefghijklmnopqrstuvwxyz"}`},
+		{name: "name-valid-upper", data: `{"a":{"n":"go","ve":"1.0"},"n":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"}`},
+		{name: "name-valid-digits", data: `{"a":{"n":"go","ve":"1.0"},"n":"0123456789"}`},
+		{name: "name-valid-special", data: `{"a":{"n":"go","ve":"1.0"},"n":"_ -"}`},
+		{name: "name-asterisk", errorKey: "n", data: `{"a":{"n":"go","ve":"1.0"},"n":"abc*"}`},
+		{name: "name-dot", errorKey: "n", data: `{"a":{"n":"go","ve":"1.0"},"n":"abc."}`},
+	}
+	testValidation(t, "m", testcases, "se")
+	testValidation(t, "x", testcases, "c", "se")
+}
+
+func TestLabelValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "valid", data: `{"k1":"v1","k2":2.3,"k3":3,"k4":true,"k5":null}`},
+		{name: "restricted-type", errorKey: "typesVals", data: `{"k1":{"k2":"v1"}}`},
+		{name: "key-dot", errorKey: "patternKeys", data: `{"k.1":"v1"}`},
+		{name: "key-asterisk", errorKey: "patternKeys", data: `{"k*1":"v1"}`},
+		{name: "key-quotemark", errorKey: "patternKeys", data: `{"k\"1":"v1"}`},
+		{name: "max-len", data: `{"k1":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "max-len-exceeded", errorKey: "maxVals", data: `{"k1":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "m", testcases, "l")
+}
+
+func TestMaxLenValidationRules(t *testing.T) {
+	// this tests an arbitrary field to ensure the `max` rule on strings works as expected
+	testcases := []testcase{
+		{name: "service-environment-max-len",
+			data: `{"a":{"n":"go","ve":"1.0"},"n":"my-service","en":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "service-environment-max-len", errorKey: "max",
+			data: `{"a":{"n":"go","ve":"1.0"},"n":"my-service","en":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "m", testcases, "se")
+}
+
+func TestContextValidationRules(t *testing.T) {
+	t.Run("custom", func(t *testing.T) {
+		testcases := []testcase{
+			{name: "custom", data: `{"cu":{"k1":{"v1":123,"v2":"value"},"k2":34,"k3":[{"a.1":1,"b*\"":2}]}}`},
+			{name: "custom-key-dot", errorKey: "patternKeys", data: `{"cu":{"k1.":{"v1":123,"v2":"value"}}}`},
+			{name: "custom-key-asterisk", errorKey: "patternKeys", data: `{"cu":{"k1*":{"v1":123,"v2":"value"}}}`},
+			{name: "custom-key-quote", errorKey: "patternKeys", data: `{"cu":{"k1\"":{"v1":123,"v2":"value"}}}`},
+		}
+		testValidation(t, "x", testcases, "c")
+	})
+
+	t.Run("tags", func(t *testing.T) {
+		testcases := []testcase{
+			{name: "tags", data: `{"g":{"k1":"v1.s*\"","k2":34,"k3":23.56,"k4":true}}`},
+			{name: "tags-key-dot", errorKey: "patternKeys", data: `{"g":{"k1.":"v1"}}`},
+			{name: "tags-key-asterisk", errorKey: "patternKeys", data: `{"g":{"k1*":"v1"}}`},
+			{name: "tags-key-quote", errorKey: "patternKeys", data: `{"g":{"k1\"":"v1"}}`},
+			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"g":{"k1":{"v1":"abc"}}}`},
+			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"g":{"k1":{"v1":[1,2,3]}}}`},
+			{name: "tags-maxVal", data: `{"g":{"k1":"` + modeldecodertest.BuildString(1024) + `"}}`},
+			{name: "tags-maxVal-exceeded", errorKey: "maxVals", data: `{"g":{"k1":"` + modeldecodertest.BuildString(1025) + `"}}`},
+		}
+		testValidation(t, "x", testcases, "c")
+	})
+}
+
+func TestDurationValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "duration", data: `0.0`},
+		{name: "duration", errorKey: "min", data: `-0.09`},
+	}
+	testValidation(t, "x", testcases, "d")
+}
+
+func TestMarksValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "marks", data: `{"k1":{"v1":12.3}}`},
+		{name: "marks-dot", errorKey: "patternKeys", data: `{"k.1":{"v1":12.3}}`},
+		{name: "marks-event-dot", errorKey: "patternKeys", data: `{"k1":{"v.1":12.3}}`},
+		{name: "marks-asterisk", errorKey: "patternKeys", data: `{"k*1":{"v1":12.3}}`},
+		{name: "marks-event-asterisk", errorKey: "patternKeys", data: `{"k1":{"v*1":12.3}}`},
+		{name: "marks-quote", errorKey: "patternKeys", data: `{"k\"1":{"v1":12.3}}`},
+		{name: "marks-event-quote", errorKey: "patternKeys", data: `{"k1":{"v\"1":12.3}}`},
+	}
+	testValidation(t, "x", testcases, "k")
+}
+
+func TestOutcomeValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "outcome-success", data: `"success"`},
+		{name: "outcome-failure", data: `"failure"`},
+		{name: "outcome-unknown", data: `"unknown"`},
+		{name: "outcome-invalid", errorKey: "enum", data: `"anything"`},
+	}
+	testValidation(t, "x", testcases, "o")
+}
+
+func TestMetadataRequiredValidationRules(t *testing.T) {
+	// setup: create full metadata struct with arbitrary values set
+	var metadata metadata
+	modeldecodertest.InitStructValues(&metadata)
+
+	// test vanilla struct is valid
+	require.NoError(t, metadata.validate())
+
+	// iterate through struct, remove every key one by one
+	// and test that validation behaves as expected
+	requiredKeys := map[string]interface{}{
+		"se":       nil, //service
+		"se.a":     nil, //service.agent
+		"se.a.n":   nil, //service.agent.name
+		"se.a.ve":  nil, //service.agent.version
+		"se.la.n":  nil, //service.language.name
+		"se.ru.n":  nil, //service.runtime.name
+		"se.ru.ve": nil, //service.runtime.version
+		"se.n":     nil, //service.name
+	}
+	modeldecodertest.SetZeroStructValue(&metadata, func(key string) {
+		err := metadata.validate()
+		if _, ok := requiredKeys[key]; ok {
+			require.Error(t, err, key)
+			for _, part := range strings.Split(key, ".") {
+				assert.Contains(t, err.Error(), part)
+			}
+		} else {
+			assert.NoError(t, err, key)
+		}
+	})
+}
+
+func TestTransactionRequiredValidationRules(t *testing.T) {
+	// setup: create full metadata struct with arbitrary values set
+	var event transaction
+	modeldecodertest.InitStructValues(&event)
+	// test vanilla struct is valid
+	require.NoError(t, event.validate())
+
+	// iterate through struct, remove every key one by one
+	// and test that validation behaves as expected
+	requiredKeys := map[string]interface{}{"d": nil,
+		"id":           nil,
+		"yc":           nil,
+		"yc.sd":        nil,
+		"tid":          nil,
+		"t":            nil,
+		"c.q.mt":       nil,
+		"exp.lt.count": nil,
+		"exp.lt.sum":   nil,
+		"exp.lt.max":   nil,
+	}
+	modeldecodertest.SetZeroStructValue(&event, func(key string) {
+		err := event.validate()
+		if _, ok := requiredKeys[key]; ok {
+			require.Error(t, err, key)
+			for _, part := range strings.Split(key, ".") {
+				assert.Contains(t, err.Error(), part)
+			}
+		} else {
+			assert.NoError(t, err, key)
+		}
+	})
+}
+
+func TestResetIsSet(t *testing.T) {
+	for name, root := range map[string]setter{
+		"m": &metadataRoot{},
+		"x": &transactionRoot{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := testdataReader(t, testFileName(name))
+			modeldecodertest.DecodeData(t, r, name, &root)
+			require.True(t, root.IsSet())
+			// call Reset and ensure initial state, except for array capacity
+			root.Reset()
+			assert.False(t, root.IsSet())
+		})
+	}
+}
+
+type testcase struct {
+	name     string
+	errorKey string
+	data     string
+}
+
+type setter interface {
+	IsSet() bool
+	Reset()
+}
+
+type validator interface {
+	validate() error
+}
+
+func testdataReader(t *testing.T, typ string) io.Reader {
+	p := filepath.Join("..", "..", "..", "testdata", "intake-v3", fmt.Sprintf("%s.ndjson", typ))
+	r, err := os.Open(p)
+	require.NoError(t, err)
+	return r
+}
+
+func testFileName(eventType string) string {
+	switch eventType {
+	case "me":
+		return eventType
+	default:
+		return "rum_events"
+	}
+}
+
+func testValidation(t *testing.T, eventType string, testcases []testcase, keys ...string) {
+	for _, tc := range testcases {
+		t.Run(tc.name+"/"+eventType, func(t *testing.T) {
+			var event validator
+			switch eventType {
+			case "m":
+				event = &metadata{}
+			case "x":
+				event = &transaction{}
+				// case "y":
+				// 	event = &span{}
+			}
+			r := testdataReader(t, testFileName(eventType))
+			modeldecodertest.DecodeDataWithReplacement(t, r, eventType, tc.data, event, keys...)
+
+			// run validation and checks
+			err := event.validate()
+			if tc.errorKey == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorKey)
+			}
+		})
+	}
+}

--- a/model/modeldecoder/rumv3/transaction_test.go
+++ b/model/modeldecoder/rumv3/transaction_test.go
@@ -33,15 +33,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestTransactionSetResetIsSet(t *testing.T) {
-	var tRoot transactionRoot
-	modeldecodertest.DecodeData(t, testdataReader(t, "rum_events"), "x", &tRoot)
-	require.True(t, tRoot.IsSet())
-	// call Reset and ensure initial state, except for array capacity
-	tRoot.Reset()
-	assert.False(t, tRoot.IsSet())
-}
-
 func TestResetTransactionOnRelease(t *testing.T) {
 	inp := `{"x":{"n":"tr-a"}}`
 	tr := fetchTransactionRoot()
@@ -50,6 +41,7 @@ func TestResetTransactionOnRelease(t *testing.T) {
 	releaseTransactionRoot(tr)
 	assert.False(t, tr.IsSet())
 }
+
 func TestDecodeNestedTransaction(t *testing.T) {
 	t.Run("decode", func(t *testing.T) {
 		now := time.Now()
@@ -82,6 +74,7 @@ func TestDecodeNestedTransaction(t *testing.T) {
 		assert.Contains(t, err.Error(), "validation")
 	})
 }
+
 func TestDecodeMapToTransactionModel(t *testing.T) {
 	localhostIP := net.ParseIP("127.0.0.1")
 	gatewayIP := net.ParseIP("192.168.0.1")
@@ -188,156 +181,4 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		assert.Equal(t, "https", *tr.Page.URL.Scheme)
 	})
 
-}
-
-func TestTransactionValidationRules(t *testing.T) {
-	testTransaction := func(t *testing.T, key string, tc testcase) {
-		var event transaction
-		r := testdataReader(t, "rum_events")
-		modeldecodertest.DecodeDataWithReplacement(t, r, "x", key, tc.data, &event)
-		// run validation and checks
-		err := event.validate()
-		if tc.errorKey == "" {
-			assert.NoError(t, err)
-		} else {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.errorKey)
-		}
-	}
-
-	t.Run("context", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "custom", data: `{"cu":{"k1":{"v1":123,"v2":"value"},"k2":34,"k3":[{"a.1":1,"b*\"":2}]}}`},
-			{name: "custom-key-dot", errorKey: "patternKeys", data: `{"cu":{"k1.":{"v1":123,"v2":"value"}}}`},
-			{name: "custom-key-asterisk", errorKey: "patternKeys", data: `{"cu":{"k1*":{"v1":123,"v2":"value"}}}`},
-			{name: "custom-key-quote", errorKey: "patternKeys", data: `{"cu":{"k1\"":{"v1":123,"v2":"value"}}}`},
-			{name: "tags", data: `{"g":{"k1":"v1.s*\"","k2":34,"k3":23.56,"k4":true}}`},
-			{name: "tags-key-dot", errorKey: "patternKeys", data: `{"g":{"k1.":"v1"}}`},
-			{name: "tags-key-asterisk", errorKey: "patternKeys", data: `{"g":{"k1*":"v1"}}`},
-			{name: "tags-key-quote", errorKey: "patternKeys", data: `{"g":{"k1\"":"v1"}}`},
-			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"g":{"k1":{"v1":"abc"}}}`},
-			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"g":{"k1":{"v1":[1,2,3]}}}`},
-			{name: "tags-maxVal", data: `{"g":{"k1":"` + modeldecodertest.BuildString(1024) + `"}}`},
-			{name: "tags-maxVal-exceeded", errorKey: "maxVals", data: `{"g":{"k1":"` + modeldecodertest.BuildString(1025) + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "c", tc)
-			})
-		}
-	})
-
-	// this tests an arbitrary field to ensure the max rule works as expected
-	t.Run("max", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "trace-id-max", data: `"` + modeldecodertest.BuildString(1024) + `"`},
-			{name: "trace-id-max-exceeded", errorKey: "max", data: `"` + modeldecodertest.BuildString(1025) + `"`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "tid", tc)
-			})
-		}
-	})
-
-	t.Run("service", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "service-name-az", data: `{"se":{"n":"abcdefghijklmnopqrstuvwxyz"}}`},
-			{name: "service-name-AZ", data: `{"se":{"n":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"}}`},
-			{name: "service-name-09 _-", data: `{"se":{"n":"0123456789 -_"}}`},
-			{name: "service-name-invalid", errorKey: "regexpAlphaNumericExt", data: `{"se":{"n":"⌘"}}`},
-			{name: "service-name-max", data: `{"e":{"n":"` + modeldecodertest.BuildStringWith(1024, '-') + `"}}`},
-			{name: "service-name-max-exceeded", errorKey: "max", data: `{"se":{"n":"` + modeldecodertest.BuildStringWith(1025, '-') + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "c", tc)
-			})
-		}
-	})
-
-	t.Run("duration", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "duration", data: `0.0`},
-			{name: "duration", errorKey: "min", data: `-0.09`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "d", tc)
-			})
-		}
-	})
-
-	t.Run("marks", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "marks", data: `{"k1":{"v1":12.3}}`},
-			{name: "marks-dot", errorKey: "patternKeys", data: `{"k.1":{"v1":12.3}}`},
-			{name: "marks-event-dot", errorKey: "patternKeys", data: `{"k1":{"v.1":12.3}}`},
-			{name: "marks-asterisk", errorKey: "patternKeys", data: `{"k*1":{"v1":12.3}}`},
-			{name: "marks-event-asterisk", errorKey: "patternKeys", data: `{"k1":{"v*1":12.3}}`},
-			{name: "marks-quote", errorKey: "patternKeys", data: `{"k\"1":{"v1":12.3}}`},
-			{name: "marks-event-quote", errorKey: "patternKeys", data: `{"k1":{"v\"1":12.3}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "k", tc)
-			})
-		}
-	})
-
-	t.Run("outcome", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "outcome-success", data: `"success"`},
-			{name: "outcome-failure", data: `"failure"`},
-			{name: "outcome-unknown", data: `"unknown"`},
-			{name: "outcome-invalid", errorKey: "enum", data: `"anything"`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "o", tc)
-			})
-		}
-	})
-
-	t.Run("user", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "id-string", data: `{"u":{"id":"user123"}}`},
-			{name: "id-int", data: `{"u":{"id":44}}`},
-			{name: "id-float", errorKey: "types", data: `{"u":{"id":45.6}}`},
-			{name: "id-bool", errorKey: "types", data: `{"u":{"id":true}}`},
-			{name: "id-string-max-len", data: `{"u":{"id":"` + modeldecodertest.BuildString(1024) + `"}}`},
-			{name: "id-string-max-len-exceeded", errorKey: "max", data: `{"u":{"id":"` + modeldecodertest.BuildString(1025) + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "c", tc)
-			})
-		}
-	})
-
-	t.Run("required", func(t *testing.T) {
-		// setup: create full metadata struct with arbitrary values set
-		var event transaction
-		modeldecodertest.InitStructValues(&event)
-		// test vanilla struct is valid
-		require.NoError(t, event.validate())
-
-		// iterate through struct, remove every key one by one
-		// and test that validation behaves as expected
-		requiredKeys := map[string]interface{}{"d": nil,
-			"id":           nil,
-			"yc":           nil,
-			"yc.sd":        nil,
-			"tid":          nil,
-			"t":            nil,
-			"c.q.mt":       nil,
-			"exp.lt.count": nil,
-			"exp.lt.sum":   nil,
-			"exp.lt.max":   nil,
-		}
-		modeldecodertest.SetZeroStructValue(&event, func(key string) {
-			err := event.validate()
-			if _, ok := requiredKeys[key]; ok {
-				require.Error(t, err, key)
-				for _, part := range strings.Split(key, ".") {
-					assert.Contains(t, err.Error(), part)
-				}
-			} else {
-				assert.NoError(t, err, key)
-			}
-		})
-	})
 }

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -19,6 +19,7 @@ package v2
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -26,11 +27,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/common"
-
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/modeldecoder"
+	"github.com/elastic/apm-server/model/modeldecoder/nullable"
 	"github.com/elastic/apm-server/utility"
 )
 
@@ -40,7 +40,6 @@ var (
 			return &metadataRoot{}
 		},
 	}
-
 	transactionRootPool = sync.Pool{
 		New: func() interface{} {
 			return &transactionRoot{}
@@ -52,43 +51,25 @@ func fetchMetadataRoot() *metadataRoot {
 	return metadataRootPool.Get().(*metadataRoot)
 }
 
-func releaseMetadataRoot(m *metadataRoot) {
-	m.Reset()
-	metadataRootPool.Put(m)
+func releaseMetadataRoot(root *metadataRoot) {
+	root.Reset()
+	metadataRootPool.Put(root)
 }
 
 func fetchTransactionRoot() *transactionRoot {
 	return transactionRootPool.Get().(*transactionRoot)
 }
 
-func releaseTransactionRoot(m *transactionRoot) {
-	m.Reset()
-	transactionRootPool.Put(m)
-}
-
-// DecodeNestedTransaction uses the given decoder to create the input model,
-// then runs the defined validations on the input model
-// and finally maps the values fom the input model to the given *model.Transaction instance
-//
-// DecodeNestedTransaction should be used when the decoder contains the `transaction` key
-func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *model.Transaction) error {
-	root := fetchTransactionRoot()
-	defer releaseTransactionRoot(root)
-	if err := d.Decode(&root); err != nil {
-		return fmt.Errorf("decode error %w", err)
-	}
-	if err := root.validate(); err != nil {
-		return fmt.Errorf("validation error %w", err)
-	}
-	mapToTransactionModel(&root.Transaction, &input.Metadata, input.RequestTime, input.Config.Experimental, out)
-	return nil
+func releaseTransactionRoot(root *transactionRoot) {
+	root.Reset()
+	transactionRootPool.Put(root)
 }
 
 // DecodeMetadata uses the given decoder to create the input model,
 // then runs the defined validations on the input model
 // and finally maps the values fom the input model to the given *model.Metadata instance
 //
-// DecodeMetadata should be used when the underlying byte stream does not contain the
+// DecodeMetadata should be used when the the stream in the decoder does not contain the
 // `metadata` key, but only the metadata data.
 func DecodeMetadata(d decoder.Decoder, out *model.Metadata) error {
 	return decodeMetadata(decodeIntoMetadata, d, out)
@@ -98,22 +79,42 @@ func DecodeMetadata(d decoder.Decoder, out *model.Metadata) error {
 // then runs the defined validations on the input model
 // and finally maps the values fom the input model to the given *model.Metadata instance
 //
-// DecodeNestedMetadata should be used when the underlying byte stream does start with the `metadata` key
+// DecodeNestedMetadata should be used when the stream in the decoder contains the `metadata` key
 func DecodeNestedMetadata(d decoder.Decoder, out *model.Metadata) error {
 	return decodeMetadata(decodeIntoMetadataRoot, d, out)
+}
+
+// DecodeNestedTransaction uses the given decoder to create the input model,
+// then runs the defined validations on the input model
+// and finally maps the values fom the input model to the given *model.Transaction instance
+//
+// DecodeNestedTransaction should be used when the stream in the decoder contains the `transaction` key
+func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *model.Transaction) error {
+	root := fetchTransactionRoot()
+	defer releaseTransactionRoot(root)
+	var err error
+	if err = d.Decode(&root); err != nil && err != io.EOF {
+		return fmt.Errorf("decode error %w", err)
+	}
+	if err := root.validate(); err != nil {
+		return fmt.Errorf("validation error %w", err)
+	}
+	mapToTransactionModel(&root.Transaction, &input.Metadata, input.RequestTime, input.Config.Experimental, out)
+	return err
 }
 
 func decodeMetadata(decFn func(d decoder.Decoder, m *metadataRoot) error, d decoder.Decoder, out *model.Metadata) error {
 	m := fetchMetadataRoot()
 	defer releaseMetadataRoot(m)
-	if err := decFn(d, m); err != nil {
+	var err error
+	if err = decFn(d, m); err != nil && err != io.EOF {
 		return fmt.Errorf("decode error %w", err)
 	}
 	if err := m.validate(); err != nil {
 		return fmt.Errorf("validation error %w", err)
 	}
 	mapToMetadataModel(&m.Metadata, out)
-	return nil
+	return err
 }
 
 func decodeIntoMetadata(d decoder.Decoder, m *metadataRoot) error {
@@ -124,266 +125,400 @@ func decodeIntoMetadataRoot(d decoder.Decoder, m *metadataRoot) error {
 	return d.Decode(m)
 }
 
-func mapToMetadataModel(m *metadata, out *model.Metadata) {
-	// Cloud
-	if m == nil {
+func mapToClientModel(from contextRequest, out *model.Metadata) {
+	// only set client information if not already set in metadata
+	// this is aligned with current logic
+	if out.Client.IP != nil {
 		return
 	}
-	if m.Cloud.Account.ID.IsSet() {
-		out.Cloud.AccountID = m.Cloud.Account.ID.Val
-	}
-	if m.Cloud.Account.Name.IsSet() {
-		out.Cloud.AccountName = m.Cloud.Account.Name.Val
-	}
-	if m.Cloud.AvailabilityZone.IsSet() {
-		out.Cloud.AvailabilityZone = m.Cloud.AvailabilityZone.Val
-	}
-	if m.Cloud.Instance.ID.IsSet() {
-		out.Cloud.InstanceID = m.Cloud.Instance.ID.Val
-	}
-	if m.Cloud.Instance.Name.IsSet() {
-		out.Cloud.InstanceName = m.Cloud.Instance.Name.Val
-	}
-	if m.Cloud.Machine.Type.IsSet() {
-		out.Cloud.MachineType = m.Cloud.Machine.Type.Val
-	}
-	if m.Cloud.Project.ID.IsSet() {
-		out.Cloud.ProjectID = m.Cloud.Project.ID.Val
-	}
-	if m.Cloud.Project.Name.IsSet() {
-		out.Cloud.ProjectName = m.Cloud.Project.Name.Val
-	}
-	if m.Cloud.Provider.IsSet() {
-		out.Cloud.Provider = m.Cloud.Provider.Val
-	}
-	if m.Cloud.Region.IsSet() {
-		out.Cloud.Region = m.Cloud.Region.Val
-	}
-
-	// Labels
-	if len(m.Labels) > 0 {
-		out.Labels = common.MapStr{}
-		out.Labels.Update(m.Labels)
-	}
-
-	// Process
-	if len(m.Process.Argv) > 0 {
-		out.Process.Argv = m.Process.Argv
-	}
-	if m.Process.Pid.IsSet() {
-		out.Process.Pid = m.Process.Pid.Val
-	}
-	if m.Process.Ppid.IsSet() {
-		var pid = m.Process.Ppid.Val
-		out.Process.Ppid = &pid
-	}
-	if m.Process.Title.IsSet() {
-		out.Process.Title = m.Process.Title.Val
-	}
-
-	// Service
-	if m.Service.Agent.EphemeralID.IsSet() {
-		out.Service.Agent.EphemeralID = m.Service.Agent.EphemeralID.Val
-	}
-	if m.Service.Agent.Name.IsSet() {
-		out.Service.Agent.Name = m.Service.Agent.Name.Val
-	}
-	if m.Service.Agent.Version.IsSet() {
-		out.Service.Agent.Version = m.Service.Agent.Version.Val
-	}
-	if m.Service.Environment.IsSet() {
-		out.Service.Environment = m.Service.Environment.Val
-	}
-	if m.Service.Framework.Name.IsSet() {
-		out.Service.Framework.Name = m.Service.Framework.Name.Val
-	}
-	if m.Service.Framework.Version.IsSet() {
-		out.Service.Framework.Version = m.Service.Framework.Version.Val
-	}
-	if m.Service.Language.Name.IsSet() {
-		out.Service.Language.Name = m.Service.Language.Name.Val
-	}
-	if m.Service.Language.Version.IsSet() {
-		out.Service.Language.Version = m.Service.Language.Version.Val
-	}
-	if m.Service.Name.IsSet() {
-		out.Service.Name = m.Service.Name.Val
-	}
-	if m.Service.Node.Name.IsSet() {
-		out.Service.Node.Name = m.Service.Node.Name.Val
-	}
-	if m.Service.Runtime.Name.IsSet() {
-		out.Service.Runtime.Name = m.Service.Runtime.Name.Val
-	}
-	if m.Service.Runtime.Version.IsSet() {
-		out.Service.Runtime.Version = m.Service.Runtime.Version.Val
-	}
-	if m.Service.Version.IsSet() {
-		out.Service.Version = m.Service.Version.Val
-	}
-
-	// System
-	if m.System.Architecture.IsSet() {
-		out.System.Architecture = m.System.Architecture.Val
-	}
-	if m.System.ConfiguredHostname.IsSet() {
-		out.System.ConfiguredHostname = m.System.ConfiguredHostname.Val
-	}
-	if m.System.Container.ID.IsSet() {
-		out.System.Container.ID = m.System.Container.ID.Val
-	}
-	if m.System.DetectedHostname.IsSet() {
-		out.System.DetectedHostname = m.System.DetectedHostname.Val
-	}
-	if !m.System.ConfiguredHostname.IsSet() && !m.System.DetectedHostname.IsSet() &&
-		m.System.HostnameDeprecated.IsSet() {
-		out.System.DetectedHostname = m.System.HostnameDeprecated.Val
-	}
-	if m.System.Kubernetes.Namespace.IsSet() {
-		out.System.Kubernetes.Namespace = m.System.Kubernetes.Namespace.Val
-	}
-	if m.System.Kubernetes.Node.Name.IsSet() {
-		out.System.Kubernetes.NodeName = m.System.Kubernetes.Node.Name.Val
-	}
-	if m.System.Kubernetes.Pod.Name.IsSet() {
-		out.System.Kubernetes.PodName = m.System.Kubernetes.Pod.Name.Val
-	}
-	if m.System.Kubernetes.Pod.UID.IsSet() {
-		out.System.Kubernetes.PodUID = m.System.Kubernetes.Pod.UID.Val
-	}
-	if m.System.Platform.IsSet() {
-		out.System.Platform = m.System.Platform.Val
-	}
-
-	// User
-	if m.User.ID.IsSet() {
-		out.User.ID = fmt.Sprint(m.User.ID.Val)
-	}
-	if m.User.Email.IsSet() {
-		out.User.Email = m.User.Email.Val
-	}
-	if m.User.Name.IsSet() {
-		out.User.Name = m.User.Name.Val
+	// http.Request.Headers and http.Request.Socket information is
+	// only set for backend events; try to first extract an IP address
+	// from the headers, if not possible use IP address from socket remote_address
+	if ip := utility.ExtractIPFromHeader(from.Headers.Val); ip != nil {
+		out.Client.IP = ip
+	} else if ip := utility.ParseIP(from.Socket.RemoteAddress.Val); ip != nil {
+		out.Client.IP = ip
 	}
 }
 
-func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime time.Time, experimental bool, out *model.Transaction) {
-	if t == nil {
+func mapToMetadataModel(from *metadata, out *model.Metadata) {
+	// Cloud
+	if from == nil {
 		return
 	}
+	if from.Cloud.Account.ID.IsSet() {
+		out.Cloud.AccountID = from.Cloud.Account.ID.Val
+	}
+	if from.Cloud.Account.Name.IsSet() {
+		out.Cloud.AccountName = from.Cloud.Account.Name.Val
+	}
+	if from.Cloud.AvailabilityZone.IsSet() {
+		out.Cloud.AvailabilityZone = from.Cloud.AvailabilityZone.Val
+	}
+	if from.Cloud.Instance.ID.IsSet() {
+		out.Cloud.InstanceID = from.Cloud.Instance.ID.Val
+	}
+	if from.Cloud.Instance.Name.IsSet() {
+		out.Cloud.InstanceName = from.Cloud.Instance.Name.Val
+	}
+	if from.Cloud.Machine.Type.IsSet() {
+		out.Cloud.MachineType = from.Cloud.Machine.Type.Val
+	}
+	if from.Cloud.Project.ID.IsSet() {
+		out.Cloud.ProjectID = from.Cloud.Project.ID.Val
+	}
+	if from.Cloud.Project.Name.IsSet() {
+		out.Cloud.ProjectName = from.Cloud.Project.Name.Val
+	}
+	if from.Cloud.Provider.IsSet() {
+		out.Cloud.Provider = from.Cloud.Provider.Val
+	}
+	if from.Cloud.Region.IsSet() {
+		out.Cloud.Region = from.Cloud.Region.Val
+	}
 
-	// prefill with metadata information, then overwrite with event specific metadata
+	// Labels
+	if len(from.Labels) > 0 {
+		out.Labels = from.Labels.Clone()
+	}
+
+	// Process
+	if len(from.Process.Argv) > 0 {
+		out.Process.Argv = from.Process.Argv
+	}
+	if from.Process.Pid.IsSet() {
+		out.Process.Pid = from.Process.Pid.Val
+	}
+	if from.Process.Ppid.IsSet() {
+		var pid = from.Process.Ppid.Val
+		out.Process.Ppid = &pid
+	}
+	if from.Process.Title.IsSet() {
+		out.Process.Title = from.Process.Title.Val
+	}
+
+	// Service
+	if from.Service.Agent.EphemeralID.IsSet() {
+		out.Service.Agent.EphemeralID = from.Service.Agent.EphemeralID.Val
+	}
+	if from.Service.Agent.Name.IsSet() {
+		out.Service.Agent.Name = from.Service.Agent.Name.Val
+	}
+	if from.Service.Agent.Version.IsSet() {
+		out.Service.Agent.Version = from.Service.Agent.Version.Val
+	}
+	if from.Service.Environment.IsSet() {
+		out.Service.Environment = from.Service.Environment.Val
+	}
+	if from.Service.Framework.Name.IsSet() {
+		out.Service.Framework.Name = from.Service.Framework.Name.Val
+	}
+	if from.Service.Framework.Version.IsSet() {
+		out.Service.Framework.Version = from.Service.Framework.Version.Val
+	}
+	if from.Service.Language.Name.IsSet() {
+		out.Service.Language.Name = from.Service.Language.Name.Val
+	}
+	if from.Service.Language.Version.IsSet() {
+		out.Service.Language.Version = from.Service.Language.Version.Val
+	}
+	if from.Service.Name.IsSet() {
+		out.Service.Name = from.Service.Name.Val
+	}
+	if from.Service.Node.Name.IsSet() {
+		out.Service.Node.Name = from.Service.Node.Name.Val
+	}
+	if from.Service.Runtime.Name.IsSet() {
+		out.Service.Runtime.Name = from.Service.Runtime.Name.Val
+	}
+	if from.Service.Runtime.Version.IsSet() {
+		out.Service.Runtime.Version = from.Service.Runtime.Version.Val
+	}
+	if from.Service.Version.IsSet() {
+		out.Service.Version = from.Service.Version.Val
+	}
+
+	// System
+	if from.System.Architecture.IsSet() {
+		out.System.Architecture = from.System.Architecture.Val
+	}
+	if from.System.ConfiguredHostname.IsSet() {
+		out.System.ConfiguredHostname = from.System.ConfiguredHostname.Val
+	}
+	if from.System.Container.ID.IsSet() {
+		out.System.Container.ID = from.System.Container.ID.Val
+	}
+	if from.System.DetectedHostname.IsSet() {
+		out.System.DetectedHostname = from.System.DetectedHostname.Val
+	}
+	if !from.System.ConfiguredHostname.IsSet() && !from.System.DetectedHostname.IsSet() &&
+		from.System.HostnameDeprecated.IsSet() {
+		out.System.DetectedHostname = from.System.HostnameDeprecated.Val
+	}
+	if from.System.Kubernetes.Namespace.IsSet() {
+		out.System.Kubernetes.Namespace = from.System.Kubernetes.Namespace.Val
+	}
+	if from.System.Kubernetes.Node.Name.IsSet() {
+		out.System.Kubernetes.NodeName = from.System.Kubernetes.Node.Name.Val
+	}
+	if from.System.Kubernetes.Pod.Name.IsSet() {
+		out.System.Kubernetes.PodName = from.System.Kubernetes.Pod.Name.Val
+	}
+	if from.System.Kubernetes.Pod.UID.IsSet() {
+		out.System.Kubernetes.PodUID = from.System.Kubernetes.Pod.UID.Val
+	}
+	if from.System.Platform.IsSet() {
+		out.System.Platform = from.System.Platform.Val
+	}
+
+	// User
+	if from.User.ID.IsSet() {
+		out.User.ID = fmt.Sprint(from.User.ID.Val)
+	}
+	if from.User.Email.IsSet() {
+		out.User.Email = from.User.Email.Val
+	}
+	if from.User.Name.IsSet() {
+		out.User.Name = from.User.Name.Val
+	}
+}
+
+func mapToPageModel(from contextPage, out *model.Page) {
+	if from.URL.IsSet() {
+		out.URL = model.ParseURL(from.URL.Val, "")
+	}
+	if from.Referer.IsSet() {
+		referer := from.Referer.Val
+		out.Referer = &referer
+	}
+}
+
+func mapToRequestModel(from contextRequest, out *model.Req) {
+	if from.Method.IsSet() {
+		out.Method = from.Method.Val
+	}
+	if len(from.Env) > 0 {
+		out.Env = from.Env.Clone()
+	}
+	if from.Socket.IsSet() {
+		out.Socket = &model.Socket{}
+		if from.Socket.Encrypted.IsSet() {
+			val := from.Socket.Encrypted.Val
+			out.Socket.Encrypted = &val
+		}
+		if from.Socket.RemoteAddress.IsSet() {
+			val := from.Socket.RemoteAddress.Val
+			out.Socket.RemoteAddress = &val
+		}
+	}
+	if from.Body.IsSet() {
+		out.Body = from.Body.Val
+	}
+	if len(from.Cookies) > 0 {
+		out.Cookies = from.Cookies.Clone()
+	}
+	if from.Headers.IsSet() {
+		out.Headers = from.Headers.Val.Clone()
+	}
+}
+
+func mapToRequestURLModel(from contextRequestURL, out *model.URL) {
+	if from.Raw.IsSet() {
+		val := from.Raw.Val
+		out.Original = &val
+	}
+	if from.Full.IsSet() {
+		val := from.Full.Val
+		out.Full = &val
+	}
+	if from.Hostname.IsSet() {
+		val := from.Hostname.Val
+		out.Domain = &val
+	}
+	if from.Path.IsSet() {
+		val := from.Path.Val
+		out.Path = &val
+	}
+	if from.Search.IsSet() {
+		val := from.Search.Val
+		out.Query = &val
+	}
+	if from.Hash.IsSet() {
+		val := from.Hash.Val
+		out.Fragment = &val
+	}
+	if from.Protocol.IsSet() {
+		trimmed := strings.TrimSuffix(from.Protocol.Val, ":")
+		out.Scheme = &trimmed
+	}
+	if from.Port.IsSet() {
+		port, err := strconv.Atoi(fmt.Sprint(from.Port.Val))
+		if err == nil {
+			out.Port = &port
+		}
+	}
+}
+
+func mapToResponseModel(from contextResponse, out *model.Resp) {
+	if from.Finished.IsSet() {
+		val := from.Finished.Val
+		out.Finished = &val
+	}
+	if from.Headers.IsSet() {
+		out.Headers = from.Headers.Val.Clone()
+	}
+	if from.HeadersSent.IsSet() {
+		val := from.HeadersSent.Val
+		out.HeadersSent = &val
+	}
+	if from.StatusCode.IsSet() {
+		val := from.StatusCode.Val
+		out.StatusCode = &val
+	}
+	if from.TransferSize.IsSet() {
+		val := from.TransferSize.Val
+		out.TransferSize = &val
+	}
+	if from.EncodedBodySize.IsSet() {
+		val := from.EncodedBodySize.Val
+		out.EncodedBodySize = &val
+	}
+	if from.DecodedBodySize.IsSet() {
+		val := from.DecodedBodySize.Val
+		out.DecodedBodySize = &val
+	}
+}
+
+func mapToServiceModel(from contextService, out *model.Service) {
+	if from.Agent.EphemeralID.IsSet() {
+		out.Agent.EphemeralID = from.Agent.EphemeralID.Val
+	}
+	if from.Agent.Name.IsSet() {
+		out.Agent.Name = from.Agent.Name.Val
+	}
+	if from.Agent.Version.IsSet() {
+		out.Agent.Version = from.Agent.Version.Val
+	}
+	if from.Environment.IsSet() {
+		out.Environment = from.Environment.Val
+	}
+	if from.Framework.Name.IsSet() {
+		out.Framework.Name = from.Framework.Name.Val
+	}
+	if from.Framework.Version.IsSet() {
+		out.Framework.Version = from.Framework.Version.Val
+	}
+	if from.Language.Name.IsSet() {
+		out.Language.Name = from.Language.Name.Val
+	}
+	if from.Language.Version.IsSet() {
+		out.Language.Version = from.Language.Version.Val
+	}
+	if from.Name.IsSet() {
+		out.Name = from.Name.Val
+	}
+	if from.Node.Name.IsSet() {
+		out.Node.Name = from.Node.Name.Val
+	}
+	if from.Runtime.Name.IsSet() {
+		out.Runtime.Name = from.Runtime.Name.Val
+	}
+	if from.Runtime.Version.IsSet() {
+		out.Runtime.Version = from.Runtime.Version.Val
+	}
+	if from.Version.IsSet() {
+		out.Version = from.Version.Val
+	}
+}
+
+func mapToTransactionModel(from *transaction, metadata *model.Metadata, reqTime time.Time, experimental bool, out *model.Transaction) {
+	// set metadata information
 	out.Metadata = *metadata
+	if from == nil {
+		return
+	}
+	// overwrite metadata with event specific information
+	mapToServiceModel(from.Context.Service, &out.Metadata.Service)
+	overwriteUserInMetadataModel(from.Context.User, &out.Metadata)
+	mapToUserAgentModel(from.Context.Request.Headers, &out.Metadata)
+	mapToClientModel(from.Context.Request, &out.Metadata)
 
-	// only set metadata Labels
-	out.Metadata.Labels = metadata.Labels.Clone()
+	// map transaction specific data
 
-	// overwrite Service values if set
-	if t.Context.Service.Agent.EphemeralID.IsSet() {
-		out.Metadata.Service.Agent.EphemeralID = t.Context.Service.Agent.EphemeralID.Val
-	}
-	if t.Context.Service.Agent.Name.IsSet() {
-		out.Metadata.Service.Agent.Name = t.Context.Service.Agent.Name.Val
-	}
-	if t.Context.Service.Agent.Version.IsSet() {
-		out.Metadata.Service.Agent.Version = t.Context.Service.Agent.Version.Val
-	}
-	if t.Context.Service.Environment.IsSet() {
-		out.Metadata.Service.Environment = t.Context.Service.Environment.Val
-	}
-	if t.Context.Service.Framework.Name.IsSet() {
-		out.Metadata.Service.Framework.Name = t.Context.Service.Framework.Name.Val
-	}
-	if t.Context.Service.Framework.Version.IsSet() {
-		out.Metadata.Service.Framework.Version = t.Context.Service.Framework.Version.Val
-	}
-	if t.Context.Service.Language.Name.IsSet() {
-		out.Metadata.Service.Language.Name = t.Context.Service.Language.Name.Val
-	}
-	if t.Context.Service.Language.Version.IsSet() {
-		out.Metadata.Service.Language.Version = t.Context.Service.Language.Version.Val
-	}
-	if t.Context.Service.Name.IsSet() {
-		out.Metadata.Service.Name = t.Context.Service.Name.Val
-	}
-	if t.Context.Service.Node.Name.IsSet() {
-		out.Metadata.Service.Node.Name = t.Context.Service.Node.Name.Val
-	}
-	if t.Context.Service.Runtime.Name.IsSet() {
-		out.Metadata.Service.Runtime.Name = t.Context.Service.Runtime.Name.Val
-	}
-	if t.Context.Service.Runtime.Version.IsSet() {
-		out.Metadata.Service.Runtime.Version = t.Context.Service.Runtime.Version.Val
-	}
-	if t.Context.Service.Version.IsSet() {
-		out.Metadata.Service.Version = t.Context.Service.Version.Val
-	}
-
-	// overwrite User specific values if set
-	// either populate all User fields or none to avoid mixing
-	// different user data
-	if t.Context.User.ID.IsSet() || t.Context.User.Email.IsSet() || t.Context.User.Name.IsSet() {
-		out.Metadata.User = model.User{}
-		if t.Context.User.ID.IsSet() {
-			out.Metadata.User.ID = fmt.Sprint(t.Context.User.ID.Val)
+	if from.Context.IsSet() {
+		if len(from.Context.Custom) > 0 {
+			custom := model.Custom(from.Context.Custom.Clone())
+			out.Custom = &custom
 		}
-		if t.Context.User.Email.IsSet() {
-			out.Metadata.User.Email = t.Context.User.Email.Val
+		// metadata labels and context labels are merged only in the output model
+		if len(from.Context.Tags) > 0 {
+			labels := model.Labels(from.Context.Tags.Clone())
+			out.Labels = &labels
 		}
-		if t.Context.User.Name.IsSet() {
-			out.Metadata.User.Name = t.Context.User.Name.Val
+		if from.Context.Message.IsSet() {
+			out.Message = &model.Message{}
+			if from.Context.Message.Age.IsSet() {
+				val := from.Context.Message.Age.Milliseconds.Val
+				out.Message.AgeMillis = &val
+			}
+			if from.Context.Message.Body.IsSet() {
+				val := from.Context.Message.Body.Val
+				out.Message.Body = &val
+			}
+			if from.Context.Message.Headers.IsSet() {
+				out.Message.Headers = from.Context.Message.Headers.Val.Clone()
+			}
+			if from.Context.Message.Queue.IsSet() && from.Context.Message.Queue.Name.IsSet() {
+				val := from.Context.Message.Queue.Name.Val
+				out.Message.QueueName = &val
+			}
 		}
-	}
-
-	if t.Context.Request.Headers.IsSet() {
-		if h := t.Context.Request.Headers.Val.Values(textproto.CanonicalMIMEHeaderKey("User-Agent")); len(h) > 0 {
-			out.Metadata.UserAgent.Original = strings.Join(h, ", ")
+		if from.Context.Page.IsSet() {
+			out.Page = &model.Page{}
+			mapToPageModel(from.Context.Page, out.Page)
+		}
+		if from.Context.Request.IsSet() {
+			out.HTTP = &model.Http{Request: &model.Req{}}
+			mapToRequestModel(from.Context.Request, out.HTTP.Request)
+			if from.Context.Request.HTTPVersion.IsSet() {
+				val := from.Context.Request.HTTPVersion.Val
+				out.HTTP.Version = &val
+			}
+		}
+		if from.Context.Request.URL.IsSet() {
+			out.URL = &model.URL{}
+			mapToRequestURLModel(from.Context.Request.URL, out.URL)
+		}
+		if from.Context.Response.IsSet() {
+			if out.HTTP == nil {
+				out.HTTP = &model.Http{}
+			}
+			out.HTTP.Response = &model.Resp{}
+			mapToResponseModel(from.Context.Response, out.HTTP.Response)
 		}
 	}
-
-	// only set client information if not already set in metadata
-	// this is aligned with current logic
-	if out.Metadata.Client.IP == nil {
-		// http.Request.Headers and http.Request.Socket information is
-		// only set for backend events; try to first extract an IP address
-		// from the headers, if not possible use IP address from socket remote_address
-		if ip := utility.ExtractIPFromHeader(t.Context.Request.Headers.Val); ip != nil {
-			out.Metadata.Client.IP = ip
-		} else if ip := utility.ParseIP(t.Context.Request.Socket.RemoteAddress.Val); ip != nil {
-			out.Metadata.Client.IP = ip
-		}
+	if from.Duration.IsSet() {
+		out.Duration = from.Duration.Val
 	}
-
-	// fill with event specific information
-
-	// metadata labels and context labels are not merged at decoder level
-	// but in the output model
-	if len(t.Context.Tags) > 0 {
-		labels := model.Labels(t.Context.Tags.Clone())
-		out.Labels = &labels
+	if from.ID.IsSet() {
+		out.ID = from.ID.Val
 	}
-	if t.Duration.IsSet() {
-		out.Duration = t.Duration.Val
-	}
-	if t.ID.IsSet() {
-		out.ID = t.ID.Val
-	}
-	if t.Marks.IsSet() {
-		out.Marks = make(model.TransactionMarks, len(t.Marks.Events))
-		for event, val := range t.Marks.Events {
+	if from.Marks.IsSet() {
+		out.Marks = make(model.TransactionMarks, len(from.Marks.Events))
+		for event, val := range from.Marks.Events {
 			if len(val.Measurements) > 0 {
 				out.Marks[event] = model.TransactionMark(val.Measurements)
 			}
 		}
 	}
-	if t.Name.IsSet() {
-		out.Name = t.Name.Val
+	if from.Name.IsSet() {
+		out.Name = from.Name.Val
 	}
-	if t.Outcome.IsSet() {
-		out.Outcome = t.Outcome.Val
+	if from.Outcome.IsSet() {
+		out.Outcome = from.Outcome.Val
 	} else {
-		if t.Context.Response.StatusCode.IsSet() {
-			statusCode := t.Context.Response.StatusCode.Val
+		if from.Context.Response.StatusCode.IsSet() {
+			statusCode := from.Context.Response.StatusCode.Val
 			if statusCode >= http.StatusInternalServerError {
 				out.Outcome = "failure"
 			} else {
@@ -393,16 +528,16 @@ func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime tim
 			out.Outcome = "unknown"
 		}
 	}
-	if t.ParentID.IsSet() {
-		out.ParentID = t.ParentID.Val
+	if from.ParentID.IsSet() {
+		out.ParentID = from.ParentID.Val
 	}
-	if t.Result.IsSet() {
-		out.Result = t.Result.Val
+	if from.Result.IsSet() {
+		out.Result = from.Result.Val
 	}
 
 	sampled := true
-	if t.Sampled.IsSet() {
-		sampled = t.Sampled.Val
+	if from.Sampled.IsSet() {
+		sampled = from.Sampled.Val
 	}
 	out.Sampled = &sampled
 
@@ -410,191 +545,79 @@ func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime tim
 	// https://github.com/elastic/apm-server/issues/4188
 	// if t.SampleRate.IsSet() {}
 
-	if t.SpanCount.Dropped.IsSet() {
-		dropped := t.SpanCount.Dropped.Val
+	if from.SpanCount.Dropped.IsSet() {
+		dropped := from.SpanCount.Dropped.Val
 		out.SpanCount.Dropped = &dropped
 	}
-	if t.SpanCount.Started.IsSet() {
-		started := t.SpanCount.Started.Val
+	if from.SpanCount.Started.IsSet() {
+		started := from.SpanCount.Started.Val
 		out.SpanCount.Started = &started
 	}
-	if t.Timestamp.Val.IsZero() {
+	if from.Timestamp.Val.IsZero() {
 		out.Timestamp = reqTime
 	} else {
-		out.Timestamp = t.Timestamp.Val
+		out.Timestamp = from.Timestamp.Val
 	}
-	if t.TraceID.IsSet() {
-		out.TraceID = t.TraceID.Val
+	if from.TraceID.IsSet() {
+		out.TraceID = from.TraceID.Val
 	}
-	if t.Type.IsSet() {
-		out.Type = t.Type.Val
+	if from.Type.IsSet() {
+		out.Type = from.Type.Val
 	}
-	if t.UserExperience.IsSet() {
+	if from.UserExperience.IsSet() {
 		out.UserExperience = &model.UserExperience{
 			CumulativeLayoutShift: -1,
 			FirstInputDelay:       -1,
 			TotalBlockingTime:     -1,
 			Longtask:              model.LongtaskMetrics{Count: -1},
 		}
-		if t.UserExperience.CumulativeLayoutShift.IsSet() {
-			out.UserExperience.CumulativeLayoutShift = t.UserExperience.CumulativeLayoutShift.Val
+		if from.UserExperience.CumulativeLayoutShift.IsSet() {
+			out.UserExperience.CumulativeLayoutShift = from.UserExperience.CumulativeLayoutShift.Val
 		}
-		if t.UserExperience.FirstInputDelay.IsSet() {
-			out.UserExperience.FirstInputDelay = t.UserExperience.FirstInputDelay.Val
+		if from.UserExperience.FirstInputDelay.IsSet() {
+			out.UserExperience.FirstInputDelay = from.UserExperience.FirstInputDelay.Val
 
 		}
-		if t.UserExperience.TotalBlockingTime.IsSet() {
-			out.UserExperience.TotalBlockingTime = t.UserExperience.TotalBlockingTime.Val
+		if from.UserExperience.TotalBlockingTime.IsSet() {
+			out.UserExperience.TotalBlockingTime = from.UserExperience.TotalBlockingTime.Val
 		}
-		if t.UserExperience.Longtask.IsSet() {
+		if from.UserExperience.Longtask.IsSet() {
 			out.UserExperience.Longtask = model.LongtaskMetrics{
-				Count: t.UserExperience.Longtask.Count.Val,
-				Sum:   t.UserExperience.Longtask.Sum.Val,
-				Max:   t.UserExperience.Longtask.Max.Val,
-			}
-		}
-	}
-	if t.Context.IsSet() {
-		if t.Context.Page.IsSet() {
-			out.Page = &model.Page{}
-			if t.Context.Page.URL.IsSet() {
-				out.Page.URL = model.ParseURL(t.Context.Page.URL.Val, "")
-			}
-			if t.Context.Page.Referer.IsSet() {
-				referer := t.Context.Page.Referer.Val
-				out.Page.Referer = &referer
-			}
-		}
-
-		if t.Context.Request.IsSet() {
-			var request model.Req
-			if t.Context.Request.Method.IsSet() {
-				request.Method = t.Context.Request.Method.Val
-			}
-			if t.Context.Request.Env.IsSet() {
-				request.Env = t.Context.Request.Env.Val
-			}
-			if t.Context.Request.Socket.IsSet() {
-				request.Socket = &model.Socket{}
-				if t.Context.Request.Socket.Encrypted.IsSet() {
-					val := t.Context.Request.Socket.Encrypted.Val
-					request.Socket.Encrypted = &val
-				}
-				if t.Context.Request.Socket.RemoteAddress.IsSet() {
-					val := t.Context.Request.Socket.RemoteAddress.Val
-					request.Socket.RemoteAddress = &val
-				}
-			}
-			if t.Context.Request.Body.IsSet() {
-				request.Body = t.Context.Request.Body.Val
-			}
-			if t.Context.Request.Cookies.IsSet() {
-				request.Cookies = t.Context.Request.Cookies.Val
-			}
-			if t.Context.Request.Headers.IsSet() {
-				request.Headers = t.Context.Request.Headers.Val.Clone()
-			}
-			out.HTTP = &model.Http{Request: &request}
-			if t.Context.Request.HTTPVersion.IsSet() {
-				val := t.Context.Request.HTTPVersion.Val
-				out.HTTP.Version = &val
-			}
-		}
-		if t.Context.Response.IsSet() {
-			if out.HTTP == nil {
-				out.HTTP = &model.Http{}
-			}
-			var response model.Resp
-			if t.Context.Response.Finished.IsSet() {
-				val := t.Context.Response.Finished.Val
-				response.Finished = &val
-			}
-			if t.Context.Response.Headers.IsSet() {
-				response.Headers = t.Context.Response.Headers.Val.Clone()
-			}
-			if t.Context.Response.HeadersSent.IsSet() {
-				val := t.Context.Response.HeadersSent.Val
-				response.HeadersSent = &val
-			}
-			if t.Context.Response.StatusCode.IsSet() {
-				val := t.Context.Response.StatusCode.Val
-				response.StatusCode = &val
-			}
-			if t.Context.Response.TransferSize.IsSet() {
-				val := t.Context.Response.TransferSize.Val
-				response.TransferSize = &val
-			}
-			if t.Context.Response.EncodedBodySize.IsSet() {
-				val := t.Context.Response.EncodedBodySize.Val
-				response.EncodedBodySize = &val
-			}
-			if t.Context.Response.DecodedBodySize.IsSet() {
-				val := t.Context.Response.DecodedBodySize.Val
-				response.DecodedBodySize = &val
-			}
-			out.HTTP.Response = &response
-		}
-		if t.Context.Request.URL.IsSet() {
-			out.URL = &model.URL{}
-			if t.Context.Request.URL.Raw.IsSet() {
-				val := t.Context.Request.URL.Raw.Val
-				out.URL.Original = &val
-			}
-			if t.Context.Request.URL.Full.IsSet() {
-				val := t.Context.Request.URL.Full.Val
-				out.URL.Full = &val
-			}
-			if t.Context.Request.URL.Hostname.IsSet() {
-				val := t.Context.Request.URL.Hostname.Val
-				out.URL.Domain = &val
-			}
-			if t.Context.Request.URL.Path.IsSet() {
-				val := t.Context.Request.URL.Path.Val
-				out.URL.Path = &val
-			}
-			if t.Context.Request.URL.Search.IsSet() {
-				val := t.Context.Request.URL.Search.Val
-				out.URL.Query = &val
-			}
-			if t.Context.Request.URL.Hash.IsSet() {
-				val := t.Context.Request.URL.Hash.Val
-				out.URL.Fragment = &val
-			}
-			if t.Context.Request.URL.Protocol.IsSet() {
-				trimmed := strings.TrimSuffix(t.Context.Request.URL.Protocol.Val, ":")
-				out.URL.Scheme = &trimmed
-			}
-			if t.Context.Request.URL.Port.IsSet() {
-				port, err := strconv.Atoi(fmt.Sprint(t.Context.Request.URL.Port.Val))
-				if err == nil {
-					out.URL.Port = &port
-				}
-			}
-		}
-		if len(t.Context.Custom) > 0 {
-			custom := model.Custom(t.Context.Custom.Clone())
-			out.Custom = &custom
-		}
-		if t.Context.Message.IsSet() {
-			out.Message = &model.Message{}
-			if t.Context.Message.Age.IsSet() {
-				val := t.Context.Message.Age.Milliseconds.Val
-				out.Message.AgeMillis = &val
-			}
-			if t.Context.Message.Body.IsSet() {
-				val := t.Context.Message.Body.Val
-				out.Message.Body = &val
-			}
-			if t.Context.Message.Headers.IsSet() {
-				out.Message.Headers = t.Context.Message.Headers.Val.Clone()
-			}
-			if t.Context.Message.Queue.IsSet() && t.Context.Message.Queue.Name.IsSet() {
-				val := t.Context.Message.Queue.Name.Val
-				out.Message.QueueName = &val
+				Count: from.UserExperience.Longtask.Count.Val,
+				Sum:   from.UserExperience.Longtask.Sum.Val,
+				Max:   from.UserExperience.Longtask.Max.Val,
 			}
 		}
 	}
 	if experimental {
-		out.Experimental = t.Experimental.Val
+		out.Experimental = from.Experimental.Val
+	}
+}
+
+func mapToUserAgentModel(from nullable.HTTPHeader, out *model.Metadata) {
+	// overwrite userAgent information if available
+	if from.IsSet() {
+		if h := from.Val.Values(textproto.CanonicalMIMEHeaderKey("User-Agent")); len(h) > 0 {
+			out.UserAgent.Original = strings.Join(h, ", ")
+		}
+	}
+}
+
+func overwriteUserInMetadataModel(from user, out *model.Metadata) {
+	// overwrite User specific values if set
+	// either populate all User fields or none to avoid mixing
+	// different user data
+	if !from.ID.IsSet() && !from.Email.IsSet() && !from.Name.IsSet() {
+		return
+	}
+	out.User = model.User{}
+	if from.ID.IsSet() {
+		out.User.ID = fmt.Sprint(from.ID.Val)
+	}
+	if from.Email.IsSet() {
+		out.User.Email = from.Email.Val
+	}
+	if from.Name.IsSet() {
+		out.User.Name = from.Name.Val
 	}
 }

--- a/model/modeldecoder/v2/metadata_test.go
+++ b/model/modeldecoder/v2/metadata_test.go
@@ -18,11 +18,7 @@
 package v2
 
 import (
-	"fmt"
-	"io"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,45 +30,6 @@ import (
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
 )
-
-type testcase struct {
-	name     string
-	errorKey string
-	data     string
-}
-
-func reader(t *testing.T, typ string) io.Reader {
-	p := filepath.Join("..", "..", "..", "testdata", "intake-v2", fmt.Sprintf("%s.ndjson", typ))
-	r, err := os.Open(p)
-	require.NoError(t, err)
-	return r
-}
-
-func TestMetadataSetResetIsSet(t *testing.T) {
-	var m metadataRoot
-	modeldecodertest.DecodeData(t, reader(t, "metadata"), "metadata", &m)
-	require.True(t, m.IsSet())
-	require.True(t, m.Metadata.Cloud.IsSet())
-	require.NotEmpty(t, m.Metadata.Labels)
-	require.True(t, m.Metadata.Process.IsSet())
-	require.True(t, m.Metadata.Service.IsSet())
-	require.True(t, m.Metadata.System.IsSet())
-	require.True(t, m.Metadata.User.IsSet())
-	// call Reset and ensure initial state, except for array capacity
-	m.Reset()
-	assert.False(t, m.IsSet())
-	assert.Equal(t, metadataCloud{}, m.Metadata.Cloud)
-	assert.Equal(t, metadataService{}, m.Metadata.Service)
-	assert.Equal(t, metadataSystem{}, m.Metadata.System)
-	assert.Equal(t, user{}, m.Metadata.User)
-	assert.Empty(t, m.Metadata.Labels)
-	assert.Empty(t, m.Metadata.Process.Pid)
-	assert.Empty(t, m.Metadata.Process.Ppid)
-	assert.Empty(t, m.Metadata.Process.Title)
-	// test that array len is set to zero, but not capacity
-	assert.Empty(t, m.Metadata.Process.Argv)
-	assert.Greater(t, cap(m.Metadata.Process.Argv), 0)
-}
 
 func TestResetMetadataOnRelease(t *testing.T) {
 	inp := `{"metadata":{"service":{"name":"service-a"}}}`
@@ -147,115 +104,4 @@ func TestDecodeMapToMetadataModel(t *testing.T) {
 	modeldecodertest.SetZeroStructValues(&m)
 	mapToMetadataModel(&m, &modelM)
 	modeldecodertest.AssertStructValues(t, &modelM, exceptions, "overwritten", 12, true, ip, time.Now())
-}
-
-func TestMetadataValidationRules(t *testing.T) {
-	testMetadata := func(t *testing.T, key string, tc testcase) {
-		var m metadata
-		r := reader(t, "metadata")
-		modeldecodertest.DecodeDataWithReplacement(t, r, "metadata", key, tc.data, &m)
-
-		// run validation and checks
-		err := m.validate()
-		if tc.errorKey == "" {
-			assert.NoError(t, err)
-		} else {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.errorKey)
-		}
-	}
-
-	t.Run("user", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "id-string", data: `{"id":"user123"}`},
-			{name: "id-int", data: `{"id":44}`},
-			{name: "id-float", errorKey: "types", data: `{"id":45.6}`},
-			{name: "id-bool", errorKey: "types", data: `{"id":true}`},
-			{name: "id-string-max-len", data: `{"id":"` + modeldecodertest.BuildString(1024) + `"}`},
-			{name: "id-string-max-len-exceeded", errorKey: "max", data: `{"id":"` + modeldecodertest.BuildString(1025) + `"}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testMetadata(t, "user", tc)
-			})
-		}
-	})
-
-	t.Run("service", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "name-valid-lower", data: `"name":"abcdefghijklmnopqrstuvwxyz"`},
-			{name: "name-valid-upper", data: `"name":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"`},
-			{name: "name-valid-digits", data: `"name":"0123456789"`},
-			{name: "name-valid-special", data: `"name":"_ -"`},
-			{name: "name-asterisk", errorKey: "pattern(regexpAlphaNumericExt)", data: `"name":"abc*"`},
-			{name: "name-dot", errorKey: "pattern(regexpAlphaNumericExt)", data: `"name":"abc."`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				tc.data = `{"agent":{"name":"go","version":"1.0"},` + tc.data + `}`
-				testMetadata(t, "service", tc)
-			})
-		}
-	})
-
-	t.Run("labels", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "valid", data: `{"k1":"v1","k2":2.3,"k3":3,"k4":true,"k5":null}`},
-			{name: "restricted-type", errorKey: "typesVals", data: `{"k1":{"k2":"v1"}}`},
-			{name: "key-dot", errorKey: "patternKeys", data: `{"k.1":"v1"}`},
-			{name: "key-asterisk", errorKey: "patternKeys", data: `{"k*1":"v1"}`},
-			{name: "key-quotemark", errorKey: "patternKeys", data: `{"k\"1":"v1"}`},
-			{name: "max-len", data: `{"k1":"` + modeldecodertest.BuildString(1024) + `"}`},
-			{name: "max-len-exceeded", errorKey: "maxVals", data: `{"k1":"` + modeldecodertest.BuildString(1025) + `"}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testMetadata(t, "labels", tc)
-			})
-		}
-	})
-
-	t.Run("max-len", func(t *testing.T) {
-		// check that `max` on strings is respected on an arbitrary field
-		for _, tc := range []testcase{
-			{name: "title-max-len", data: `{"pid":1,"title":"` + modeldecodertest.BuildString(1024) + `"}`},
-			{name: "title-max-len-exceeded", errorKey: "max",
-				data: `{"pid":1,"title":"` + modeldecodertest.BuildString(1025) + `"}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testMetadata(t, "process", tc)
-			})
-		}
-	})
-
-	t.Run("required", func(t *testing.T) {
-		// setup: create full metadata struct with arbitrary values set
-		var metadata metadata
-		modeldecodertest.InitStructValues(&metadata)
-		// test vanilla struct is valid
-		require.NoError(t, metadata.validate())
-
-		// iterate through struct, remove every key one by one
-		// and test that validation behaves as expected
-		requiredKeys := map[string]interface{}{
-			"cloud.provider":          nil,
-			"process.pid":             nil,
-			"service":                 nil,
-			"service.agent":           nil,
-			"service.agent.name":      nil,
-			"service.agent.version":   nil,
-			"service.language.name":   nil,
-			"service.runtime.name":    nil,
-			"service.runtime.version": nil,
-			"service.name":            nil,
-		}
-		modeldecodertest.SetZeroStructValue(&metadata, func(key string) {
-			err := metadata.validate()
-			if _, ok := requiredKeys[key]; ok {
-				require.Error(t, err, key)
-				for _, part := range strings.Split(key, ".") {
-					assert.Contains(t, err.Error(), part)
-				}
-			} else {
-				assert.NoError(t, err, key)
-			}
-		})
-	})
 }

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -57,9 +57,9 @@ type context struct {
 }
 
 type contextMessage struct {
+	Age     contextMessageAge   `json:"age"`
 	Body    nullable.String     `json:"body"`
 	Headers nullable.HTTPHeader `json:"headers"`
-	Age     contextMessageAge   `json:"age"`
 	Queue   contextMessageQueue `json:"queue"`
 }
 
@@ -72,19 +72,22 @@ type contextMessageQueue struct {
 }
 
 type contextPage struct {
-	URL     nullable.String `json:"url"`
 	Referer nullable.String `json:"referer"`
+	URL     nullable.String `json:"url"`
 }
 
 type contextRequest struct {
-	Cookies     nullable.Interface   `json:"cookies"`
 	Body        nullable.Interface   `json:"body" validate:"types=string;map[string]interface"`
-	Env         nullable.Interface   `json:"env"`
+	Cookies     common.MapStr        `json:"cookies"`
+	Env         common.MapStr        `json:"env"`
 	Headers     nullable.HTTPHeader  `json:"headers"`
 	HTTPVersion nullable.String      `json:"http_version" validate:"max=1024"`
 	Method      nullable.String      `json:"method" validate:"required,max=1024"`
 	Socket      contextRequestSocket `json:"socket"`
-	URL         contextRequestURL    `json:"url"` //TODO(simitt): check validate:"required"`
+	//TODO(simitt): context.request.url is currently required,
+	//              but none of its attributes is required, which could lead to
+	//              an empty URL struct - no difference to making it optional
+	URL contextRequestURL `json:"url"`
 }
 
 type contextRequestURL struct {
@@ -99,8 +102,8 @@ type contextRequestURL struct {
 }
 
 type contextRequestSocket struct {
-	RemoteAddress nullable.String `json:"remote_address"`
 	Encrypted     nullable.Bool   `json:"encrypted"`
+	RemoteAddress nullable.String `json:"remote_address"`
 }
 
 type contextResponse struct {
@@ -265,6 +268,7 @@ type metadataSystemKubernetesPod struct {
 type transaction struct {
 	Context        context                   `json:"context"`
 	Duration       nullable.Float64          `json:"duration" validate:"required,min=0"`
+	Experimental   nullable.Interface        `json:"experimental"`
 	ID             nullable.String           `json:"id" validate:"required,max=1024"`
 	Marks          transactionMarks          `json:"marks"`
 	Name           nullable.String           `json:"name" validate:"max=1024"`
@@ -278,7 +282,6 @@ type transaction struct {
 	TraceID        nullable.String           `json:"trace_id" validate:"required,max=1024"`
 	Type           nullable.String           `json:"type" validate:"required,max=1024"`
 	UserExperience transactionUserExperience `json:"experience"`
-	Experimental   nullable.Interface        `json:"experimental"`
 }
 
 type transactionMarks struct {
@@ -314,18 +317,18 @@ type transactionUserExperience struct {
 	// or a negative value if FID is unknown. See https://web.dev/fid/
 	FirstInputDelay nullable.Float64 `json:"fid" validate:"min=0"`
 
+	// Longtask holds longtask duration/count metrics.
+	Longtask longtaskMetrics `json:"longtask"`
+
 	// TotalBlockingTime holds the Total Blocking Time (TBT) metric value,
 	// or a negative value if TBT is unknown. See https://web.dev/tbt/
 	TotalBlockingTime nullable.Float64 `json:"tbt" validate:"min=0"`
-
-	// Longtask holds longtask duration/count metrics.
-	Longtask longtaskMetrics `json:"longtask"`
 }
 
 type longtaskMetrics struct {
 	Count nullable.Int     `json:"count" validate:"required,min=0"`
-	Sum   nullable.Float64 `json:"sum" validate:"required,min=0"`
 	Max   nullable.Float64 `json:"max" validate:"required,min=0"`
+	Sum   nullable.Float64 `json:"sum" validate:"required,min=0"`
 }
 
 type user struct {

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -619,12 +619,13 @@ func (val *transactionRoot) validate() error {
 }
 
 func (val *transaction) IsSet() bool {
-	return val.Context.IsSet() || val.Duration.IsSet() || val.ID.IsSet() || val.Marks.IsSet() || val.Name.IsSet() || val.Outcome.IsSet() || val.ParentID.IsSet() || val.Result.IsSet() || val.Sampled.IsSet() || val.SampleRate.IsSet() || val.SpanCount.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.Type.IsSet() || val.UserExperience.IsSet() || val.Experimental.IsSet()
+	return val.Context.IsSet() || val.Duration.IsSet() || val.Experimental.IsSet() || val.ID.IsSet() || val.Marks.IsSet() || val.Name.IsSet() || val.Outcome.IsSet() || val.ParentID.IsSet() || val.Result.IsSet() || val.Sampled.IsSet() || val.SampleRate.IsSet() || val.SpanCount.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.Type.IsSet() || val.UserExperience.IsSet()
 }
 
 func (val *transaction) Reset() {
 	val.Context.Reset()
 	val.Duration.Reset()
+	val.Experimental.Reset()
 	val.ID.Reset()
 	val.Marks.Reset()
 	val.Name.Reset()
@@ -638,7 +639,6 @@ func (val *transaction) Reset() {
 	val.TraceID.Reset()
 	val.Type.Reset()
 	val.UserExperience.Reset()
-	val.Experimental.Reset()
 }
 
 func (val *transaction) validate() error {
@@ -774,13 +774,13 @@ func (val *context) validate() error {
 }
 
 func (val *contextMessage) IsSet() bool {
-	return val.Body.IsSet() || val.Headers.IsSet() || val.Age.IsSet() || val.Queue.IsSet()
+	return val.Age.IsSet() || val.Body.IsSet() || val.Headers.IsSet() || val.Queue.IsSet()
 }
 
 func (val *contextMessage) Reset() {
+	val.Age.Reset()
 	val.Body.Reset()
 	val.Headers.Reset()
-	val.Age.Reset()
 	val.Queue.Reset()
 }
 
@@ -831,12 +831,12 @@ func (val *contextMessageQueue) validate() error {
 }
 
 func (val *contextPage) IsSet() bool {
-	return val.URL.IsSet() || val.Referer.IsSet()
+	return val.Referer.IsSet() || val.URL.IsSet()
 }
 
 func (val *contextPage) Reset() {
-	val.URL.Reset()
 	val.Referer.Reset()
+	val.URL.Reset()
 }
 
 func (val *contextPage) validate() error {
@@ -868,13 +868,17 @@ func (val *contextResponse) validate() error {
 }
 
 func (val *contextRequest) IsSet() bool {
-	return val.Cookies.IsSet() || val.Body.IsSet() || val.Env.IsSet() || val.Headers.IsSet() || val.HTTPVersion.IsSet() || val.Method.IsSet() || val.Socket.IsSet() || val.URL.IsSet()
+	return val.Body.IsSet() || len(val.Cookies) > 0 || len(val.Env) > 0 || val.Headers.IsSet() || val.HTTPVersion.IsSet() || val.Method.IsSet() || val.Socket.IsSet() || val.URL.IsSet()
 }
 
 func (val *contextRequest) Reset() {
-	val.Cookies.Reset()
 	val.Body.Reset()
-	val.Env.Reset()
+	for k := range val.Cookies {
+		delete(val.Cookies, k)
+	}
+	for k := range val.Env {
+		delete(val.Env, k)
+	}
 	val.Headers.Reset()
 	val.HTTPVersion.Reset()
 	val.Method.Reset()
@@ -912,12 +916,12 @@ func (val *contextRequest) validate() error {
 }
 
 func (val *contextRequestSocket) IsSet() bool {
-	return val.RemoteAddress.IsSet() || val.Encrypted.IsSet()
+	return val.Encrypted.IsSet() || val.RemoteAddress.IsSet()
 }
 
 func (val *contextRequestSocket) Reset() {
-	val.RemoteAddress.Reset()
 	val.Encrypted.Reset()
+	val.RemoteAddress.Reset()
 }
 
 func (val *contextRequestSocket) validate() error {
@@ -1210,14 +1214,14 @@ func (val *transactionSpanCount) validate() error {
 }
 
 func (val *transactionUserExperience) IsSet() bool {
-	return val.CumulativeLayoutShift.IsSet() || val.FirstInputDelay.IsSet() || val.TotalBlockingTime.IsSet() || val.Longtask.IsSet()
+	return val.CumulativeLayoutShift.IsSet() || val.FirstInputDelay.IsSet() || val.Longtask.IsSet() || val.TotalBlockingTime.IsSet()
 }
 
 func (val *transactionUserExperience) Reset() {
 	val.CumulativeLayoutShift.Reset()
 	val.FirstInputDelay.Reset()
-	val.TotalBlockingTime.Reset()
 	val.Longtask.Reset()
+	val.TotalBlockingTime.Reset()
 }
 
 func (val *transactionUserExperience) validate() error {
@@ -1230,23 +1234,23 @@ func (val *transactionUserExperience) validate() error {
 	if val.FirstInputDelay.Val < 0 {
 		return fmt.Errorf("'fid': validation rule 'min(0)' violated")
 	}
-	if val.TotalBlockingTime.Val < 0 {
-		return fmt.Errorf("'tbt': validation rule 'min(0)' violated")
-	}
 	if err := val.Longtask.validate(); err != nil {
 		return errors.Wrapf(err, "longtask")
+	}
+	if val.TotalBlockingTime.Val < 0 {
+		return fmt.Errorf("'tbt': validation rule 'min(0)' violated")
 	}
 	return nil
 }
 
 func (val *longtaskMetrics) IsSet() bool {
-	return val.Count.IsSet() || val.Sum.IsSet() || val.Max.IsSet()
+	return val.Count.IsSet() || val.Max.IsSet() || val.Sum.IsSet()
 }
 
 func (val *longtaskMetrics) Reset() {
 	val.Count.Reset()
-	val.Sum.Reset()
 	val.Max.Reset()
+	val.Sum.Reset()
 }
 
 func (val *longtaskMetrics) validate() error {
@@ -1259,17 +1263,17 @@ func (val *longtaskMetrics) validate() error {
 	if !val.Count.IsSet() {
 		return fmt.Errorf("'count' required")
 	}
-	if val.Sum.Val < 0 {
-		return fmt.Errorf("'sum': validation rule 'min(0)' violated")
-	}
-	if !val.Sum.IsSet() {
-		return fmt.Errorf("'sum' required")
-	}
 	if val.Max.Val < 0 {
 		return fmt.Errorf("'max': validation rule 'min(0)' violated")
 	}
 	if !val.Max.IsSet() {
 		return fmt.Errorf("'max' required")
+	}
+	if val.Sum.Val < 0 {
+		return fmt.Errorf("'sum': validation rule 'min(0)' violated")
+	}
+	if !val.Sum.IsSet() {
+		return fmt.Errorf("'sum' required")
 	}
 	return nil
 }

--- a/model/modeldecoder/v2/model_test.go
+++ b/model/modeldecoder/v2/model_test.go
@@ -1,0 +1,391 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
+	"github.com/elastic/apm-server/model/modeldecoder/nullable"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+//
+// Test Validation rules
+//
+
+func TestUserValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "id-string", data: `{"id":"user123"}`},
+		{name: "id-int", data: `{"id":44}`},
+		{name: "id-float", errorKey: "types", data: `{"id":45.6}`},
+		{name: "id-bool", errorKey: "types", data: `{"id":true}`},
+		{name: "id-string-max-len", data: `{"id":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "id-string-max-len-exceeded", errorKey: "max", data: `{"id":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "metadata", testcases, "user")
+	testValidation(t, "transaction", testcases, "context", "user")
+}
+
+func TestServiceValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "service-name-az", data: `{"agent":{"name":"go","version":"1.0"},"name":"abcdefghijklmnopqrstuvwxyz"}`},
+		{name: "service-name-AZ", data: `{"agent":{"name":"go","version":"1.0"},"name":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"}`},
+		{name: "service-name-09 _-", data: `{"agent":{"name":"go","version":"1.0"},"name":"0123456789 -_"}`},
+		{name: "service-name-invalid", errorKey: "regexpAlphaNumericExt",
+			data: `{"agent":{"name":"go","version":"1.0"},"name":"⌘"}`},
+		{name: "service-name-max", data: `{"agent":{"name":"go","version":"1.0"},"name":"` + modeldecodertest.BuildStringWith(1024, '-') + `"}`},
+		{name: "service-name-max-exceeded", errorKey: "max",
+			data: `{"agent":{"name":"go","version":"1.0"},"name":"` + modeldecodertest.BuildStringWith(1025, '-') + `"}`},
+	}
+	testValidation(t, "metadata", testcases, "service")
+	testValidation(t, "transaction", testcases, "context", "service")
+}
+
+func TestLabelValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "valid", data: `{"k1":"v1","k2":2.3,"k3":3,"k4":true,"k5":null}`},
+		{name: "restricted-type", errorKey: "typesVals", data: `{"k1":{"k2":"v1"}}`},
+		{name: "key-dot", errorKey: "patternKeys", data: `{"k.1":"v1"}`},
+		{name: "key-asterisk", errorKey: "patternKeys", data: `{"k*1":"v1"}`},
+		{name: "key-quotemark", errorKey: "patternKeys", data: `{"k\"1":"v1"}`},
+		{name: "max-len", data: `{"k1":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "max-len-exceeded", errorKey: "maxVals", data: `{"k1":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "metadata", testcases, "labels")
+}
+
+func TestMaxLenValidationRules(t *testing.T) {
+	// this tests an arbitrary field to ensure the `max` rule on strings works as expected
+	testcases := []testcase{
+		{name: "title-max-len", data: `{"pid":1,"title":"` + modeldecodertest.BuildString(1024) + `"}`},
+		{name: "title-max-len-exceeded", errorKey: "max",
+			data: `{"pid":1,"title":"` + modeldecodertest.BuildString(1025) + `"}`},
+	}
+	testValidation(t, "metadata", testcases, "process")
+}
+
+func TestContextValidationRules(t *testing.T) {
+	t.Run("custom", func(t *testing.T) {
+		testcases := []testcase{
+			{name: "custom", data: `{"custom":{"k1":{"v1":123,"v2":"value"},"k2":34,"k3":[{"a.1":1,"b*\"":2}]}}`},
+			{name: "custom-key-dot", errorKey: "patternKeys", data: `{"custom":{"k1.":{"v1":123,"v2":"value"}}}`},
+			{name: "custom-key-asterisk", errorKey: "patternKeys", data: `{"custom":{"k1*":{"v1":123,"v2":"value"}}}`},
+			{name: "custom-key-quote", errorKey: "patternKeys", data: `{"custom":{"k1\"":{"v1":123,"v2":"value"}}}`},
+		}
+		testValidation(t, "transaction", testcases, "context")
+	})
+
+	t.Run("tags", func(t *testing.T) {
+		testcases := []testcase{
+			{name: "tags", data: `{"tags":{"k1":"v1.s*\"","k2":34,"k3":23.56,"k4":true}}`},
+			{name: "tags-key-dot", errorKey: "patternKeys", data: `{"tags":{"k1.":"v1"}}`},
+			{name: "tags-key-asterisk", errorKey: "patternKeys", data: `{"tags":{"k1*":"v1"}}`},
+			{name: "tags-key-quote", errorKey: "patternKeys", data: `{"tags":{"k1\"":"v1"}}`},
+			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"tags":{"k1":{"v1":"abc"}}}`},
+			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"tags":{"k1":{"v1":[1,2,3]}}}`},
+			{name: "tags-maxVal", data: `{"tags":{"k1":"` + modeldecodertest.BuildString(1024) + `"}}`},
+			{name: "tags-maxVal-exceeded", errorKey: "maxVals", data: `{"tags":{"k1":"` + modeldecodertest.BuildString(1025) + `"}}`},
+		}
+		testValidation(t, "transaction", testcases, "context")
+	})
+
+	t.Run("request", func(t *testing.T) {
+		testcases := []testcase{
+			{name: "request-body-string", data: `{"request":{"method":"get","body":"value"}}`},
+			{name: "request-body-object", data: `{"request":{"method":"get","body":{"a":"b"}}}`},
+			{name: "request-body-array", errorKey: "body",
+				data: `{"request":{"method":"get","body":[1,2]}}`},
+		}
+		testValidation(t, "transaction", testcases, "context")
+	})
+}
+
+func TestDurationValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "duration", data: `0.0`},
+		{name: "duration", errorKey: "min", data: `-0.09`},
+	}
+	testValidation(t, "transaction", testcases, "duration")
+}
+
+func TestMarksValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "marks", data: `{"k1":{"v1":12.3}}`},
+		{name: "marks-dot", errorKey: "patternKeys", data: `{"k.1":{"v1":12.3}}`},
+		{name: "marks-events-dot", errorKey: "patternKeys", data: `{"k1":{"v.1":12.3}}`},
+		{name: "marks-asterisk", errorKey: "patternKeys", data: `{"k*1":{"v1":12.3}}`},
+		{name: "marks-events-asterisk", errorKey: "patternKeys", data: `{"k1":{"v*1":12.3}}`},
+		{name: "marks-quote", errorKey: "patternKeys", data: `{"k\"1":{"v1":12.3}}`},
+		{name: "marks-events-quote", errorKey: "patternKeys", data: `{"k1":{"v\"1":12.3}}`},
+	}
+	testValidation(t, "transaction", testcases, "marks")
+}
+
+func TestOutcomeValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "outcome-success", data: `"success"`},
+		{name: "outcome-failure", data: `"failure"`},
+		{name: "outcome-unknown", data: `"unknown"`},
+		{name: "outcome-invalid", errorKey: "enum", data: `"anything"`},
+	}
+	testValidation(t, "transaction", testcases, "outcome")
+}
+
+func TestURLValidationRules(t *testing.T) {
+	testcases := []testcase{
+		{name: "port-string", data: `{"request":{"method":"get","url":{"port":"8200"}}}`},
+		{name: "port-int", data: `{"request":{"method":"get","url":{"port":8200}}}`},
+		{name: "port-invalid-type", errorKey: "types",
+			data: `{"request":{"method":"get","url":{"port":[8200,8201]}}}`},
+		{name: "port-invalid-type", errorKey: "types",
+			data: `{"request":{"method":"get","url":{"port":{"val":8200}}}}`},
+	}
+	testValidation(t, "transaction", testcases, "context")
+}
+
+//
+// Test Reset()
+//
+
+func TestReset(t *testing.T) {
+	addStr := func(s string) nullable.String {
+		ns := nullable.String{}
+		ns.Set(s)
+		return ns
+	}
+	decode := func(t *testing.T, inp string, out interface{}) {
+		require.NoError(t, decoder.NewJSONIteratorDecoder(strings.NewReader(inp)).Decode(&out))
+	}
+	t.Run("struct", func(t *testing.T) {
+		var out metadataServiceNode
+		inputs := []string{`{"configured_name":"a"}`, `{"configured_name":"b"}`, `{}`}
+		expected := []metadataServiceNode{{Name: addStr("a")}, {Name: addStr("b")}, {}}
+		for i := 0; i < len(inputs); i++ {
+			out.Reset()
+			decode(t, inputs[i], &out)
+			assert.Equal(t, expected[i], out)
+		}
+	})
+	t.Run("map", func(t *testing.T) {
+		var out metadata
+		inputs := []string{
+			`{"labels":{"a":"1","b":"s","c":true}}}`,
+			`{"labels":{"a":"new"}}}`,
+			`{}`}
+		expected := []metadata{
+			{Labels: common.MapStr{"a": "1", "b": "s", "c": true}},
+			{Labels: common.MapStr{"a": "new"}},
+			{Labels: common.MapStr{}}}
+		for i := 0; i < len(inputs); i++ {
+			out.Reset()
+			decode(t, inputs[i], &out)
+			assert.Equal(t, expected[i], out)
+		}
+	})
+	t.Run("map-structs", func(t *testing.T) {
+		var out transaction
+		inputs := []string{
+			`{"marks":{"group1":{"meas1":43.5,"meas2":23.5},"group2":{"a":1,"b":14}}}`,
+			`{"marks":{"group1":{"meas1":14}}}`,
+			`{}`,
+		}
+		expected := []transaction{
+			{Marks: transactionMarks{Events: map[string]transactionMarkEvents{
+				"group1": {Measurements: map[string]float64{"meas1": 43.5, "meas2": 23.5}},
+				"group2": {Measurements: map[string]float64{"a": 1, "b": 14}}}}},
+			{Marks: transactionMarks{Events: map[string]transactionMarkEvents{
+				"group1": {Measurements: map[string]float64{"meas1": 14}}}}},
+			{Marks: transactionMarks{Events: map[string]transactionMarkEvents{}}}}
+		for i := 0; i < len(inputs); i++ {
+			out.Reset()
+			decode(t, inputs[i], &out)
+			assert.Equal(t, expected[i], out)
+		}
+	})
+	t.Run("slice", func(t *testing.T) {
+		var out metadataProcess
+		inputs := []string{
+			`{"argv":["a","b"]}`,
+			`{"argv":["c"]}`,
+			`{}`}
+		expected := []metadataProcess{
+			{Argv: []string{"a", "b"}},
+			{Argv: []string{"c"}},
+			{Argv: []string{}}}
+		for i := 0; i < len(inputs); i++ {
+			out.Reset()
+			decode(t, inputs[i], &out)
+			assert.Equal(t, expected[i], out)
+		}
+	})
+}
+
+//
+// Test Required fields
+//
+
+func TestMetadataRequiredValidationRules(t *testing.T) {
+	// setup: create full metadata struct with arbitrary values set
+	var metadata metadata
+	modeldecodertest.InitStructValues(&metadata)
+	// test vanilla struct is valid
+	require.NoError(t, metadata.validate())
+
+	// iterate through struct, remove every key one by one
+	// and test that validation behaves as expected
+	requiredKeys := map[string]interface{}{
+		"cloud.provider":          nil,
+		"process.pid":             nil,
+		"service":                 nil,
+		"service.agent":           nil,
+		"service.agent.name":      nil,
+		"service.agent.version":   nil,
+		"service.language.name":   nil,
+		"service.runtime.name":    nil,
+		"service.runtime.version": nil,
+		"service.name":            nil,
+	}
+	modeldecodertest.SetZeroStructValue(&metadata, func(key string) {
+		err := metadata.validate()
+		if _, ok := requiredKeys[key]; ok {
+			require.Error(t, err, key)
+			for _, part := range strings.Split(key, ".") {
+				assert.Contains(t, err.Error(), part)
+			}
+		} else {
+			assert.NoError(t, err, key)
+		}
+	})
+}
+func TestTransactionRequiredValidationRules(t *testing.T) {
+	// setup: create full struct with arbitrary values set
+	var event transaction
+	modeldecodertest.InitStructValues(&event)
+	// test vanilla struct is valid
+	require.NoError(t, event.validate())
+
+	// iterate through struct, remove every key one by one
+	// and test that validation behaves as expected
+	requiredKeys := map[string]interface{}{
+		"duration":                  nil,
+		"id":                        nil,
+		"span_count":                nil,
+		"span_count.started":        nil,
+		"trace_id":                  nil,
+		"type":                      nil,
+		"context.request.method":    nil,
+		"experience.longtask.count": nil,
+		"experience.longtask.sum":   nil,
+		"experience.longtask.max":   nil,
+	}
+	modeldecodertest.SetZeroStructValue(&event, func(key string) {
+		err := event.validate()
+		if _, ok := requiredKeys[key]; ok {
+			require.Error(t, err, key)
+			for _, part := range strings.Split(key, ".") {
+				assert.Contains(t, err.Error(), part)
+			}
+		} else {
+			assert.NoError(t, err, key)
+		}
+	})
+}
+
+//
+// Test Set() and Reset()
+//
+
+func TestResetIsSet(t *testing.T) {
+	for name, root := range map[string]setter{
+		"metadata":    &metadataRoot{},
+		"transaction": &transactionRoot{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := testdataReader(t, testFileName(name))
+			modeldecodertest.DecodeData(t, r, name, &root)
+			require.True(t, root.IsSet())
+			// call Reset and ensure initial state, except for array capacity
+			root.Reset()
+			assert.False(t, root.IsSet())
+		})
+	}
+}
+
+type setter interface {
+	IsSet() bool
+	Reset()
+}
+
+type validator interface {
+	validate() error
+}
+
+type testcase struct {
+	name     string
+	errorKey string
+	data     string
+}
+
+func testdataReader(t *testing.T, typ string) io.Reader {
+	p := filepath.Join("..", "..", "..", "testdata", "intake-v2", fmt.Sprintf("%s.ndjson", typ))
+	r, err := os.Open(p)
+	require.NoError(t, err)
+	return r
+}
+
+func testFileName(eventType string) string {
+	if eventType == "metadata" {
+		return eventType
+	}
+	return eventType + "s"
+}
+
+func testValidation(t *testing.T, eventType string, testcases []testcase, keys ...string) {
+	for _, tc := range testcases {
+		t.Run(tc.name+"/"+eventType, func(t *testing.T) {
+			var event validator
+			switch eventType {
+			case "metadata":
+				event = &metadata{}
+			case "transaction":
+				event = &transaction{}
+			}
+			r := testdataReader(t, testFileName(eventType))
+			modeldecodertest.DecodeDataWithReplacement(t, r, eventType, tc.data, event, keys...)
+
+			// run validation and checks
+			err := event.validate()
+			if tc.errorKey == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorKey)
+			}
+		})
+	}
+}

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -34,22 +34,13 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestTransactionSetResetIsSet(t *testing.T) {
-	var tRoot transactionRoot
-	modeldecodertest.DecodeData(t, reader(t, "transactions"), "transaction", &tRoot)
-	require.True(t, tRoot.IsSet())
-	// call Reset and ensure initial state, except for array capacity
-	tRoot.Reset()
-	assert.False(t, tRoot.IsSet())
-}
-
 func TestResetTransactionOnRelease(t *testing.T) {
 	inp := `{"transaction":{"name":"tr-a"}}`
-	tr := fetchTransactionRoot()
-	require.NoError(t, decoder.NewJSONIteratorDecoder(strings.NewReader(inp)).Decode(tr))
-	require.True(t, tr.IsSet())
-	releaseTransactionRoot(tr)
-	assert.False(t, tr.IsSet())
+	root := fetchTransactionRoot()
+	require.NoError(t, decoder.NewJSONIteratorDecoder(strings.NewReader(inp)).Decode(root))
+	require.True(t, root.IsSet())
+	releaseTransactionRoot(root)
+	assert.False(t, root.IsSet())
 }
 
 func TestDecodeNestedTransaction(t *testing.T) {
@@ -109,66 +100,66 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 
 	t.Run("set-metadata", func(t *testing.T) {
 		// do not overwrite metadata with zero transaction values
-		var inputTr transaction
-		var tr model.Transaction
-		mapToTransactionModel(&inputTr, initializedMeta(), time.Now(), true, &tr)
+		var input transaction
+		var out model.Transaction
+		mapToTransactionModel(&input, initializedMeta(), time.Now(), true, &out)
 		// iterate through metadata model and assert values are set
-		modeldecodertest.AssertStructValues(t, &tr.Metadata, exceptions, "meta", 1, false, localhostIP, time.Now())
+		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, "meta", 1, false, localhostIP, time.Now())
 	})
 
 	t.Run("overwrite-metadata", func(t *testing.T) {
 		// overwrite defined metadata with transaction metadata values
-		var inputTr transaction
-		var tr model.Transaction
-		modeldecodertest.SetStructValues(&inputTr, "overwritten", 5000, false, time.Now())
-		inputTr.Context.Request.Headers.Val.Add("user-agent", "first")
-		inputTr.Context.Request.Headers.Val.Add("user-agent", "second")
-		inputTr.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
-		mapToTransactionModel(&inputTr, initializedMeta(), time.Now(), true, &tr)
+		var input transaction
+		var out model.Transaction
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, false, time.Now())
+		input.Context.Request.Headers.Val.Add("user-agent", "first")
+		input.Context.Request.Headers.Val.Add("user-agent", "second")
+		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
+		mapToTransactionModel(&input, initializedMeta(), time.Now(), true, &out)
 
 		// user-agent should be set to context request header values
-		assert.Equal(t, "first, second", tr.Metadata.UserAgent.Original)
+		assert.Equal(t, "first, second", out.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
-		assert.Equal(t, localhostIP, tr.Metadata.Client.IP, tr.Metadata.Client.IP.String())
+		assert.Equal(t, localhostIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
 		// metadata labels and transaction labels should not be merged
-		assert.Equal(t, common.MapStr{"meta": "meta"}, tr.Metadata.Labels)
-		assert.Equal(t, &model.Labels{"overwritten": "overwritten"}, tr.Labels)
+		assert.Equal(t, common.MapStr{"meta": "meta"}, out.Metadata.Labels)
+		assert.Equal(t, &model.Labels{"overwritten": "overwritten"}, out.Labels)
 		// service values should be set
-		modeldecodertest.AssertStructValues(t, &tr.Metadata.Service, exceptions, "overwritten", 100, true, localhostIP, time.Now())
+		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, "overwritten", 100, true, localhostIP, time.Now())
 		// user values should be set
-		modeldecodertest.AssertStructValues(t, &tr.Metadata.User, exceptions, "overwritten", 100, true, localhostIP, time.Now())
+		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, "overwritten", 100, true, localhostIP, time.Now())
 	})
 
 	t.Run("client-ip-header", func(t *testing.T) {
-		var inputTr transaction
-		var tr model.Transaction
-		inputTr.Context.Request.Headers.Set(http.Header{})
-		inputTr.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
-		inputTr.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
-		mapToTransactionModel(&inputTr, &model.Metadata{}, time.Now(), false, &tr)
-		assert.Equal(t, gatewayIP, tr.Metadata.Client.IP, tr.Metadata.Client.IP.String())
+		var input transaction
+		var out model.Transaction
+		input.Context.Request.Headers.Set(http.Header{})
+		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
+		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
+		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), false, &out)
+		assert.Equal(t, gatewayIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
 	})
 
 	t.Run("client-ip-socket", func(t *testing.T) {
-		var inputTr transaction
-		var tr model.Transaction
-		inputTr.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
-		mapToTransactionModel(&inputTr, &model.Metadata{}, time.Now(), false, &tr)
-		assert.Equal(t, randomIP, tr.Metadata.Client.IP, tr.Metadata.Client.IP.String())
+		var input transaction
+		var out model.Transaction
+		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
+		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), false, &out)
+		assert.Equal(t, randomIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
 	})
 
 	t.Run("overwrite-user", func(t *testing.T) {
 		// user should be populated by metadata or event specific, but not merged
-		var inputTr transaction
-		var tr model.Transaction
-		inputTr.Context.User.Email.Set("test@user.com")
-		mapToTransactionModel(&inputTr, initializedMeta(), time.Now(), false, &tr)
-		assert.Equal(t, "test@user.com", tr.Metadata.User.Email)
-		assert.Zero(t, tr.Metadata.User.ID)
-		assert.Zero(t, tr.Metadata.User.Name)
+		var input transaction
+		var out model.Transaction
+		input.Context.User.Email.Set("test@user.com")
+		mapToTransactionModel(&input, initializedMeta(), time.Now(), false, &out)
+		assert.Equal(t, "test@user.com", out.Metadata.User.Email)
+		assert.Zero(t, out.Metadata.User.ID)
+		assert.Zero(t, out.Metadata.User.Name)
 	})
 
-	t.Run("other-transaction-values", func(t *testing.T) {
+	t.Run("transaction-values", func(t *testing.T) {
 		exceptions := func(key string) bool {
 			// metadata are tested separately
 			// URL parts are derived from url (separately tested)
@@ -182,209 +173,30 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 			return false
 		}
 
-		var inputTr transaction
-		var tr model.Transaction
+		var input transaction
+		var out model.Transaction
 		eventTime, reqTime := time.Now(), time.Now().Add(time.Second)
-		modeldecodertest.SetStructValues(&inputTr, "overwritten", 5000, true, eventTime)
-		mapToTransactionModel(&inputTr, initializedMeta(), reqTime, true, &tr)
-		modeldecodertest.AssertStructValues(t, &tr, exceptions, "overwritten", 5000, true, localhostIP, eventTime)
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, eventTime)
+		mapToTransactionModel(&input, initializedMeta(), reqTime, true, &out)
+		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, localhostIP, eventTime)
 
 		// set requestTime if eventTime is zero
-		modeldecodertest.SetStructValues(&inputTr, "overwritten", 5000, true, time.Time{})
-		mapToTransactionModel(&inputTr, initializedMeta(), reqTime, true, &tr)
-		modeldecodertest.AssertStructValues(t, &tr, exceptions, "overwritten", 5000, true, localhostIP, reqTime)
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, time.Time{})
+		out = model.Transaction{}
+		mapToTransactionModel(&input, initializedMeta(), reqTime, true, &out)
+		input.Reset()
+		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, localhostIP, reqTime)
 
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
-		var inputTr transaction
-		inputTr.Context.Page.URL.Set("https://my.site.test:9201")
-		var tr model.Transaction
-		mapToTransactionModel(&inputTr, initializedMeta(), time.Now(), false, &tr)
-		assert.Equal(t, "https://my.site.test:9201", *tr.Page.URL.Full)
-		assert.Equal(t, 9201, *tr.Page.URL.Port)
-		assert.Equal(t, "https", *tr.Page.URL.Scheme)
+		var input transaction
+		input.Context.Page.URL.Set("https://my.site.test:9201")
+		var out model.Transaction
+		mapToTransactionModel(&input, initializedMeta(), time.Now(), false, &out)
+		assert.Equal(t, "https://my.site.test:9201", *out.Page.URL.Full)
+		assert.Equal(t, 9201, *out.Page.URL.Port)
+		assert.Equal(t, "https", *out.Page.URL.Scheme)
 	})
 
-}
-
-func TestTransactionValidationRules(t *testing.T) {
-	testTransaction := func(t *testing.T, key string, tc testcase) {
-		var event transaction
-		r := reader(t, "transactions")
-		modeldecodertest.DecodeDataWithReplacement(t, r, "transaction", key, tc.data, &event)
-
-		// run validation and checks
-		err := event.validate()
-		if tc.errorKey == "" {
-			assert.NoError(t, err)
-		} else {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.errorKey)
-		}
-	}
-
-	t.Run("context", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "custom", data: `{"custom":{"k1":{"v1":123,"v2":"value"},"k2":34,"k3":[{"a.1":1,"b*\"":2}]}}`},
-			{name: "custom-key-dot", errorKey: "patternKeys", data: `{"custom":{"k1.":{"v1":123,"v2":"value"}}}`},
-			{name: "custom-key-asterisk", errorKey: "patternKeys", data: `{"custom":{"k1*":{"v1":123,"v2":"value"}}}`},
-			{name: "custom-key-quote", errorKey: "patternKeys", data: `{"custom":{"k1\"":{"v1":123,"v2":"value"}}}`},
-			{name: "tags", data: `{"tags":{"k1":"v1.s*\"","k2":34,"k3":23.56,"k4":true}}`},
-			{name: "tags-key-dot", errorKey: "patternKeys", data: `{"tags":{"k1.":"v1"}}`},
-			{name: "tags-key-asterisk", errorKey: "patternKeys", data: `{"tags":{"k1*":"v1"}}`},
-			{name: "tags-key-quote", errorKey: "patternKeys", data: `{"tags":{"k1\"":"v1"}}`},
-			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"tags":{"k1":{"v1":"abc"}}}`},
-			{name: "tags-invalid-type", errorKey: "typesVals", data: `{"tags":{"k1":{"v1":[1,2,3]}}}`},
-			{name: "tags-maxVal", data: `{"tags":{"k1":"` + modeldecodertest.BuildString(1024) + `"}}`},
-			{name: "tags-maxVal-exceeded", errorKey: "maxVals", data: `{"tags":{"k1":"` + modeldecodertest.BuildString(1025) + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	// this tests an arbitrary field to ensure the max rule works as expected
-	t.Run("max", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "context-message-queue-name", data: `{"message":{"queue":{"name":"` + modeldecodertest.BuildString(1024) + `"}}}`},
-			{name: "context-message-queue-name", errorKey: "max", data: `{"message":{"queue":{"name":"` + modeldecodertest.BuildString(1025) + `"}}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	t.Run("request", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "request-body-string", data: `"body":"value"`},
-			{name: "request-body-object", data: `"body":{"a":"b"}`},
-			{name: "request-body-array", errorKey: "types(string;map[string]interface)", data: `"body":[1,2]`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				tc.data = `{"request":{"method":"get",` + tc.data + `}}`
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	t.Run("service", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "service-name-az", data: `{"service":{"name":"abcdefghijklmnopqrstuvwxyz"}}`},
-			{name: "service-name-AZ", data: `{"service":{"name":"ABCDEFGHIJKLMNOPQRSTUVWXYZ"}}`},
-			{name: "service-name-09 _-", data: `{"service":{"name":"0123456789 -_"}}`},
-			{name: "service-name-invalid", errorKey: "regexpAlphaNumericExt", data: `{"service":{"name":"⌘"}}`},
-			{name: "service-name-max", data: `{"service":{"name":"` + modeldecodertest.BuildStringWith(1024, '-') + `"}}`},
-			{name: "service-name-max-exceeded", errorKey: "max", data: `{"service":{"name":"` + modeldecodertest.BuildStringWith(1025, '-') + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	t.Run("duration", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "duration", data: `0.0`},
-			{name: "duration", errorKey: "min", data: `-0.09`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "duration", tc)
-			})
-		}
-	})
-
-	t.Run("marks", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "marks", data: `{"k1":{"v1":12.3}}`},
-			{name: "marks-dot", errorKey: "patternKeys", data: `{"k.1":{"v1":12.3}}`},
-			{name: "marks-events-dot", errorKey: "patternKeys", data: `{"k1":{"v.1":12.3}}`},
-			{name: "marks-asterisk", errorKey: "patternKeys", data: `{"k*1":{"v1":12.3}}`},
-			{name: "marks-events-asterisk", errorKey: "patternKeys", data: `{"k1":{"v*1":12.3}}`},
-			{name: "marks-quote", errorKey: "patternKeys", data: `{"k\"1":{"v1":12.3}}`},
-			{name: "marks-events-quote", errorKey: "patternKeys", data: `{"k1":{"v\"1":12.3}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "marks", tc)
-			})
-		}
-	})
-
-	t.Run("outcome", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "outcome-success", data: `"success"`},
-			{name: "outcome-failure", data: `"failure"`},
-			{name: "outcome-unknown", data: `"unknown"`},
-			{name: "outcome-invalid", errorKey: "enum", data: `"anything"`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "outcome", tc)
-			})
-		}
-	})
-
-	t.Run("url", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "port-string", data: `"port":"8200"`},
-			{name: "port-int", data: `"port":8200`},
-			{name: "port-invalid-type", errorKey: "types", data: `"port":[8200,8201]`},
-			{name: "port-invalid-type", errorKey: "types", data: `"port":{"val":8200}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				tc.data = `{"request":{"method":"get","url":{` + tc.data + `}}}`
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	t.Run("user", func(t *testing.T) {
-		for _, tc := range []testcase{
-			{name: "id-string", data: `{"user":{"id":"user123"}}`},
-			{name: "id-int", data: `{"user":{"id":44}}`},
-			{name: "id-float", errorKey: "types", data: `{"user":{"id":45.6}}`},
-			{name: "id-bool", errorKey: "types", data: `{"user":{"id":true}}`},
-			{name: "id-string-max-len", data: `{"user":{"id":"` + modeldecodertest.BuildString(1024) + `"}}`},
-			{name: "id-string-max-len-exceeded", errorKey: "max", data: `{"user":{"id":"` + modeldecodertest.BuildString(1025) + `"}}`},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				testTransaction(t, "context", tc)
-			})
-		}
-	})
-
-	t.Run("required", func(t *testing.T) {
-		// setup: create full metadata struct with arbitrary values set
-		var event transaction
-		modeldecodertest.InitStructValues(&event)
-		// test vanilla struct is valid
-		require.NoError(t, event.validate())
-
-		// iterate through struct, remove every key one by one
-		// and test that validation behaves as expected
-		requiredKeys := map[string]interface{}{
-			"duration":                  nil,
-			"id":                        nil,
-			"span_count":                nil,
-			"span_count.started":        nil,
-			"trace_id":                  nil,
-			"type":                      nil,
-			"context.request.method":    nil,
-			"experience.longtask.count": nil,
-			"experience.longtask.sum":   nil,
-			"experience.longtask.max":   nil,
-		}
-		modeldecodertest.SetZeroStructValue(&event, func(key string) {
-			err := event.validate()
-			if _, ok := requiredKeys[key]; ok {
-				require.Error(t, err, key)
-				for _, part := range strings.Split(key, ".") {
-					assert.Contains(t, err.Error(), part)
-				}
-			} else {
-				assert.NoError(t, err, key)
-			}
-		})
-	})
 }


### PR DESCRIPTION
## Motivation/summary
This PR fixes a small bug and extends the functionality of the modeldecoder test logic, which uncovered also a bug in the model (using `interface` instead of `mapstr` for some json objects).

    * fix small bug in model definition for objects

    * fix bug in populator test logic

    * restructure validation tests to make them easier extensible for future events
    without repetition

I created the PR on top of https://github.com/elastic/apm-server/pull/4258 to keep the diff small and will rebase to `elastic/master` later on. 

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001]~(https://github.com/elastic/kibana/issues/44001))
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
`make update` generates the `model_generated.go` file
run `make test` to ensure all tests are still working

## Related issues
related to #3551 